### PR TITLE
Move without encoder

### DIFF
--- a/smarActApp/src/smarActMCSMotorDriver.cpp
+++ b/smarActApp/src/smarActMCSMotorDriver.cpp
@@ -531,8 +531,6 @@ SmarActMCSAxis::move(double position, int relative, double min_vel, double max_v
 			fmt = fmt_lin;
 		}
 
-		printf("with encoder\n");
-
 #ifdef DEBUG
 		printf("Move to %f (speed %f - %f)\n", position, min_vel, max_vel);
 #endif
@@ -560,7 +558,6 @@ SmarActMCSAxis::move(double position, int relative, double min_vel, double max_v
 	}
 	else
 	{
-		printf("without encoder\n");
 		fmt = fmt_step;
 
 		rpos = rint(position);

--- a/smarActApp/src/smarActMCSMotorDriver.cpp
+++ b/smarActApp/src/smarActMCSMotorDriver.cpp
@@ -261,6 +261,13 @@ int val;
 	c_p_->getIntegerParam(axisNo_, c_p_->motorClosedLoop_, &val);
 	return val;
 }
+int
+SmarActMCSAxis::getEncoder()
+{
+int val;
+	c_p_->getIntegerParam(axisNo_, c_p_->motorStatusHasEncoder_, &val);
+	return val;
+}
 
 SmarActMCSAxis::SmarActMCSAxis(class SmarActMCSController *cnt_p, int axis, int channel)
 	: asynMotorAxis(cnt_p, axis), c_p_(cnt_p)
@@ -380,7 +387,7 @@ SmarActMCSAxis::poll(bool* moving_p)
 	int                    rev;
 	enum SmarActMCSStatus status;
 
-	if (getClosedLoop())
+	if (getEncoder())
 	{
 		if (isRot_) {
 			if ((comStatus_ = getAngle(&angle, &rev)))
@@ -515,7 +522,7 @@ SmarActMCSAxis::move(double position, int relative, double min_vel, double max_v
 	double rpos;
 	long angle;
 	int rev;
-	if (getClosedLoop())
+	if (getEncoder())
 	{
 		if (isRot_) {
 			fmt = fmt_rot;
@@ -524,6 +531,7 @@ SmarActMCSAxis::move(double position, int relative, double min_vel, double max_v
 			fmt = fmt_lin;
 		}
 
+		printf("with encoder\n");
 
 #ifdef DEBUG
 		printf("Move to %f (speed %f - %f)\n", position, min_vel, max_vel);
@@ -552,6 +560,7 @@ SmarActMCSAxis::move(double position, int relative, double min_vel, double max_v
 	}
 	else
 	{
+		printf("without encoder\n");
 		fmt = fmt_step;
 
 		rpos = rint(position);
@@ -622,7 +631,7 @@ SmarActMCSAxis::setPosition(double position)
 	double rpos;
 
 	rpos = rint(position);
-	if (getClosedLoop()) {
+	if (getEncoder()) {
 		if (isRot_) {
 			// For rotation stages the revolution will always be set to zero
 			// Only set position if it is between zero an 360 degrees

--- a/smarActApp/src/smarActMCSMotorDriver.cpp
+++ b/smarActApp/src/smarActMCSMotorDriver.cpp
@@ -566,8 +566,9 @@ SmarActMCSAxis::move(double position, int relative, double min_vel, double max_v
 		rpos = rint(position);
 		if (relative == 0 ) // absolute move
 		{
-			rpos -= stepCount_; // subtract current step count to produce steps for this move
+			int diff = rpos - stepCount_;
 			stepCount_ = rpos;
+			rpos = diff; // subtract current step count to produce steps for this move
 		}
 		else
 		{
@@ -580,9 +581,9 @@ SmarActMCSAxis::move(double position, int relative, double min_vel, double max_v
 		// overload max_vel as frequency
 		int frequency = (max_vel> MAX_FREQ) ? (MAX_FREQ) : ((max_vel< 1) ? (1) : (max_vel));
 
-//#ifdef DEBUG
-		printf("Step Move to %ld (piezo voltage %d ,frequency %d)\n", (long)rpos, amplitude, frequency);
-//#endif
+#ifdef DEBUG
+		printf("Open loop Step to %ld (piezo voltage %d ,frequency %d)\n", (long)rpos, amplitude, frequency);
+#endif
 		// overload accel as frequency
 		comStatus_ = moveCmd(fmt, channel_, (long)rpos, amplitude, frequency);
 	}

--- a/smarActApp/src/smarActMCSMotorDriver.h
+++ b/smarActApp/src/smarActMCSMotorDriver.h
@@ -55,6 +55,7 @@ public:
 	virtual asynStatus getAngle(int *val_p, int *rev_p);
 	virtual asynStatus moveCmd(const char *cmd, ...);
 	virtual int        getClosedLoop();
+	int        getEncoder();
 
 	int         getVel() const { return vel_; }
 	

--- a/smarActApp/src/smarActMCSMotorDriver.h
+++ b/smarActApp/src/smarActMCSMotorDriver.h
@@ -57,10 +57,10 @@ public:
 	virtual int        getClosedLoop();
 
 	int         getVel() const { return vel_; }
-
+	
 protected:
 	asynStatus  setSpeed(double velocity);
-
+	int getEncoder();
 private:
 	SmarActMCSController   *c_p_;  // pointer to asynMotorController for this axis
 	asynStatus             comStatus_;

--- a/smarActApp/src/smarActMCSMotorDriver.h
+++ b/smarActApp/src/smarActMCSMotorDriver.h
@@ -69,6 +69,7 @@ private:
 	int                    channel_;
 	int                    sensorType_;
 	int                    isRot_;
+	int					   stepCount_; // open loop current step count
 
 friend class SmarActMCSController;
 };

--- a/smarActApp/src/smarActMCSMotorDriver.h
+++ b/smarActApp/src/smarActMCSMotorDriver.h
@@ -61,7 +61,6 @@ public:
 	
 protected:
 	asynStatus  setSpeed(double velocity);
-	int getEncoder();
 private:
 	SmarActMCSController   *c_p_;  // pointer to asynMotorController for this axis
 	asynStatus             comStatus_;


### PR DESCRIPTION
I added code to allow smarActMCS controller to work with motors without encoder.
Any comments are welcome. (This is my first attempt to modify EPICS code).

This change is best described by Mark Rivers email (copied below):

Each axis object has a new flag indicating whether or not it has an encoder. 
Each axis object has a new variable to store the current position.
If the axis has an encoder the current behavior is not changed and the new position variable is not used.
If the axis does not have an encoder the new position variable is used to keep track of the position. 
  Each time the axis is homed this position variable is set to 0.
  Each time the axis does a relative move the position variable is incremented accordingly
  Each time the axis does an absolute move it is converted to a relative move by comparing with the current position, and then the current position is updated.
Do the axes without encoders have a way of saying when the move is in progress and then is complete?
  If yes then only update the motor readback to the new position when it is complete.
  If no then update the motor readback to the new position when the move starts.

