### PR TITLE
Add extra flag to disable smarActMCS speed set commands

### DIFF
--- a/docs/README.SmarActMCS
+++ b/docs/README.SmarActMCS
@@ -179,7 +179,8 @@ smarActMCSCreateController(
      const char *ioPortName,
      int         numAxes,
      double      movingPollPeriod,
-     double      idlePollPeriod);
+     double      idlePollPeriod,
+     int         disableSpeed);
 
   motorPortName: unique string to identify this
                  instance to be used in the
@@ -201,12 +202,17 @@ smarActMCSCreateController(
                  the MCS is polled for status
                  changes while the positioner
                  is stopped.
+  disableSpeed:  The commands to get/set speed
+                 are not available on some 
+                 smarAct controllers. If set, 
+                 this flag disable all the 
+                 speed commands in the driver.
 
 E.g., to configure a driver with one axis using
 the serial connection 'myTS1' configured in the
 prior example we use
 
-smarActMCSCreateController("myMotor1","myTS1",1,0.02,1.0)
+smarActMCSCreateController("myMotor1","myTS1",1,0.02,1.0,0)
 
 This results in a polling interval of 20ms 
 while moving and 1s while idle. The driver

--- a/iocs/smarActIOC/iocBoot/iocSmarAct/smaractmcs.iocsh
+++ b/iocs/smarActIOC/iocBoot/iocSmarAct/smaractmcs.iocsh
@@ -6,8 +6,8 @@ dbLoadTemplate "motor.substitutions.smaractmcs"
 drvAsynIPPortConfigure("MCS_ETH","192.168.1.17:2102",0,0,0)
 
 # Controller port, asyn port, number of axis, moving poll period, idle poll period
-# smarActMCSCreateController(const char *motorPortName, const char *ioPortName, int numAxes, double movingPollPeriod, double idlePollPeriod);
-smarActMCSCreateController("MCS", "MCS_ETH", 1, 0.020, 1.0)
+# smarActMCSCreateController(const char *motorPortName, const char *ioPortName, int numAxes, double movingPollPeriod, double idlePollPeriod, int disableSpeed);
+smarActMCSCreateController("MCS", "MCS_ETH", 1, 0.020, 1.0, 0)
 
 # Controller port, axis number, controller channel
 # smarActMCSCreateAxis(const char *motorPortName, int axisNumber, int channel)

--- a/smarActApp/src/smarActMCSMotorDriver.h
+++ b/smarActApp/src/smarActMCSMotorDriver.h
@@ -76,7 +76,7 @@ friend class SmarActMCSController;
 class SmarActMCSController : public asynMotorController
 {
 public:
-	SmarActMCSController(const char *portName, const char *IOPortName, int numAxes, double movingPollPeriod, double idlePollPeriod);
+	SmarActMCSController(const char *portName, const char *IOPortName, int numAxes, double movingPollPeriod, double idlePollPeriod, int disableSpeed = 0);
 	virtual asynStatus sendCmd(size_t *got_p, char *rep, int len, double timeout, const char *fmt, va_list ap);
 	virtual asynStatus sendCmd(size_t *got_p, char *rep, int len, double timeout, const char *fmt, ...);
 	virtual asynStatus sendCmd(size_t *got_p, char *rep, int len, const char *fmt, ...);
@@ -90,6 +90,7 @@ protected:
 
 private:
 	asynUser *asynUserMot_p_;
+	int disableSpeed_;
 friend class SmarActMCSAxis;
 };
 


### PR DESCRIPTION
@kmpeters I've tested with a controller that does and does not support the GCLS commands and it seems to be working fine.