### PR TITLE
support sensorless positioner

### DIFF
--- a/smarActApp/src/smarActMCS2MotorDriver.cpp
+++ b/smarActApp/src/smarActMCS2MotorDriver.cpp
@@ -372,45 +372,27 @@ asynStatus MCS2Axis::move(double position, int relative, double minVelocity, dou
     sprintf(pC_->outString_, ":MOVE%d %f", channel_, position * PULSES_PER_STEP);
     status = pC_->writeController();
   } else {
-    printf("=================\n");
 
-    printf("current step position      = %d\n", stepTarget_);
-    printf("new target position (r=%d) = %f\n", relative, position);
-    int dtg = position - stepTarget_;
-    printf("distance to go             = %d\n", dtg);
-    stepTarget_ = (int)position;
-    printf("step tgt= %d\n", stepTarget_);
+    PositionType dtg = position - stepTarget_;  // distance to go
+    stepTarget_ = (PositionType)position;       // store position in global scope
 
-    printf("---------\nMOVE\n");
-    // Set mode
+    // Set mode; 4 == STEP
     sprintf(pC_->outString_, ":CHAN%d:MMOD 4", channel_);
-    printf(pC_->outString_);
     status = pC_->writeController();
-    /* printf("%s\n", pC_->outString_); check_for_error(); */
 
-    // Set amplitude
-    sprintf(pC_->outString_, ":CHAN%d:STEP:AMPL 32767", channel_);
-    printf(pC_->outString_);
+    // Set frequency; range 1..20000 Hz
+    unsigned short frequency = (unsigned short)maxVelocity;
+    if(frequency >= MAX_FREQUENCY) {
+      frequency = MAX_FREQUENCY;
+    }
+    sprintf(pC_->outString_, ":CHAN%d:STEP:FREQ %u", channel_, frequency);
+    printf("----> %s\n", pC_->outString_);
     status = pC_->writeController();
-    /* printf("%s\n", pC_->outString_); check_for_error(); */
-
-    // Set frequency
-    sprintf(pC_->outString_, ":CHAN%d:STEP:FREQ %d", channel_, (long)maxVelocity);
-    printf(pC_->outString_);
-    status = pC_->writeController();
-    /* printf("%s\n", pC_->outString_); check_for_error(); */
 
     // Do move
-    sprintf(pC_->outString_, ":MOVE%d %f", channel_, (double)dtg);
-    printf(pC_->outString_);
+    sprintf(pC_->outString_, ":MOVE%d %lld", channel_, dtg);
     status = pC_->writeController();
-    printf("%s\n", pC_->outString_);
-    printf("----------\nset position to %f\n", stepTarget_);
     setDoubleParam(pC_->motorPosition_, (double)stepTarget_);
-    printf("THE END = %f\n", pC_->motorPosition_);
-    printf("---------------\n");
-
-//    setDoubleParam(pC_->motorEncoderPosition_, position);
   }
 
   return status;

--- a/smarActApp/src/smarActMCS2MotorDriver.cpp
+++ b/smarActApp/src/smarActMCS2MotorDriver.cpp
@@ -357,8 +357,8 @@ asynStatus MCS2Axis::move(double position, int relative, double minVelocity, dou
    *	- relative=1
    *	- step=4
    */
-
   if(sensorPresent_) {
+    // closed loop move
     // Set hold time
     sprintf(pC_->outString_, ":CHAN%d:MMOD %d", channel_, relative > 0 ? 1 : 0);
     status = pC_->writeController();
@@ -372,23 +372,19 @@ asynStatus MCS2Axis::move(double position, int relative, double minVelocity, dou
     sprintf(pC_->outString_, ":MOVE%d %f", channel_, position * PULSES_PER_STEP);
     status = pC_->writeController();
   } else {
-
+    // open loop move
     PositionType dtg = position - stepTarget_;  // distance to go
     stepTarget_ = (PositionType)position;       // store position in global scope
-
     // Set mode; 4 == STEP
     sprintf(pC_->outString_, ":CHAN%d:MMOD 4", channel_);
     status = pC_->writeController();
-
     // Set frequency; range 1..20000 Hz
     unsigned short frequency = (unsigned short)maxVelocity;
     if(frequency >= MAX_FREQUENCY) {
       frequency = MAX_FREQUENCY;
     }
     sprintf(pC_->outString_, ":CHAN%d:STEP:FREQ %u", channel_, frequency);
-    printf("----> %s\n", pC_->outString_);
     status = pC_->writeController();
-
     // Do move
     sprintf(pC_->outString_, ":MOVE%d %lld", channel_, dtg);
     status = pC_->writeController();

--- a/smarActApp/src/smarActMCS2MotorDriver.h
+++ b/smarActApp/src/smarActMCS2MotorDriver.h
@@ -38,6 +38,8 @@ The two that may be of significant interest are:
  * If this scaling was not implemented the maximum range would be ~2.147 mm/deg, now it's ~2147 mm/deg */
 #define PULSES_PER_STEP 1000
 
+typedef long long PositionType;
+
 /** MCS2 Axis status flags **/
 const unsigned short ACTIVELY_MOVING         = 0x0001;
 const unsigned short CLOSED_LOOP_ACTIVE      = 0x0002;
@@ -65,6 +67,7 @@ const unsigned short   STOP_ON_REF_FOUND       = 0x0020;
 
 /** MCS2 Axis constants **/
 #define HOLD_FOREVER 0xffffffff
+#define MAX_FREQUENCY 20000
 
 /** drvInfo strings for extra parameters that the MCS2 controller supports */
 #define MCS2MclfString "MCLF"
@@ -91,7 +94,7 @@ private:
                                 *   Abbreviated because it is used very frequently */
   int channel_;
   int sensorPresent_;
-  int stepTarget_ = 0;
+  PositionType stepTarget_ = 0;
   asynStatus comStatus_;
 
 friend class MCS2Controller;

--- a/smarActApp/src/smarActMCS2MotorDriver.h
+++ b/smarActApp/src/smarActMCS2MotorDriver.h
@@ -90,9 +90,10 @@ private:
   MCS2Controller *pC_;      /**< Pointer to the asynMotorController to which this axis belongs.
                                 *   Abbreviated because it is used very frequently */
   int channel_;
+  int sensorPresent_;
+  int stepTarget_ = 0;
   asynStatus comStatus_;
 
-  
 friend class MCS2Controller;
 };
 


### PR DESCRIPTION
Sensorless positioners timeout at the `:CHAN%d:POS?` command.
In case the positioner does not provide sensor data `sensorPresent==0` the device support will use the open loop command for the move.