### PR TITLE
reindent code / merge features of MCS driver that were lost since from version 1.5.0

### DIFF
--- a/smarActApp/src/smarActMCS2MotorDriver.cpp
+++ b/smarActApp/src/smarActMCS2MotorDriver.cpp
@@ -23,6 +23,12 @@ Jan 19, 2019
 #include <epicsExport.h>
 #include "smarActMCS2MotorDriver.h"
 
+#ifdef DEBUG
+  #define DBG_PRINTF(...) printf(__VA_ARGS__)
+#else
+  #define DBG_PRINTF(...)
+#endif
+
 static const char *driverName = "SmarActMCS2MotorDriver";
 
 /** Creates a new MCS2Controller object.
@@ -46,11 +52,11 @@ MCS2Controller::MCS2Controller(const char *portName, const char *MCS2PortName, i
   asynPrint(this->pasynUserSelf, ASYN_TRACEIO_DRIVER, "MCS2Controller::MCS2Controller: Creating controller\n");
 
   // Create controller-specific parameters
-  createParam(MCS2MclfString, asynParamInt32, &this->mclf_);
   createParam(MCS2PtypString, asynParamInt32, &this->ptyp_);
   createParam(MCS2PtypRbString, asynParamInt32, &this->ptyprb_);
   createParam(MCS2PstatString, asynParamInt32, &this->pstatrb_); // whole positioner status word
-  createParam(MCS2RefString, asynParamInt32, &this->ref_);
+  createParam(MCS2MclfString, asynParamInt32, &this->mclf_);
+  createParam(MCS2HoldString, asynParamInt32, &this->hold_);
   createParam(MCS2CalString, asynParamInt32, &this->cal_);
 
   // Connect to MCS2 controller
@@ -214,19 +220,25 @@ asynStatus MCS2Controller::writeInt32(asynUser *pasynUser, epicsInt32 value)
    * status at the end, but that's OK */
   status = setIntegerParam(pAxis->axisNo_, function, value);
 
-  if (function == mclf_) {
-    // set MCLF
-    sprintf(pAxis->pC_->outString_, ":CHAN%d:MCLF:CURR %d", pAxis->axisNo_, value);
-    status = pAxis->pC_->writeController();
-  }
-  else if (function == ptyp_) {
+  if (function == ptyp_) {
     // set positioner type
     sprintf(pAxis->pC_->outString_, ":CHAN%d:PTYP %d", pAxis->axisNo_, value);
+    status = pAxis->pC_->writeController();
+  }
+  else if (function == mclf_) {
+    // set piezo MaxClockFreq
+    sprintf(pAxis->pC_->outString_, ":CHAN%d:MCLF:CURR %d", pAxis->axisNo_, value);
     status = pAxis->pC_->writeController();
   }
   else if (function == cal_) {
     // send calibration command
     sprintf(pAxis->pC_->outString_, ":CAL%d", pAxis->axisNo_);
+    status = pAxis->pC_->writeController();
+  }
+  else if (function == hold_) {
+    // set holding time
+    sprintf(pAxis->pC_->outString_, ":CHAN%d:HOLD %d", pAxis->axisNo_, value);
+    puts(pAxis->pC_->outString_);
     status = pAxis->pC_->writeController();
   }
   else {
@@ -259,14 +271,8 @@ MCS2Axis::MCS2Axis(MCS2Controller *pC, int axisNo)
     : asynMotorAxis(pC, axisNo),
       pC_(pC)
 {
-  // asynStatus status;
-
   asynPrint(pC->pasynUserSelf, ASYN_TRACEIO_DRIVER, "MCS2Axis::MCS2Axis: Creating axis %u\n", axisNo);
   channel_ = axisNo;
-
-  // Set hold time
-  sprintf(pC_->outString_, ":CHAN%d:HOLD %d", channel_, HOLD_FOREVER);
-  /*status = */ pC_->writeController();
   pC_->clearErrors();
   callParamCallbacks();
 }
@@ -346,14 +352,18 @@ asynStatus MCS2Axis::move(double position, int relative, double minVelocity, dou
 {
   asynStatus status = asynSuccess;
 
-  /* MCS2 move mode is:
-   *	- absolute=0
-   *	- relative=1
-   *	- step=4
-   */
-  if(sensorPresent_) {
-    // closed loop move
-    // Set hold time
+  // MCS2 MMOD (move mode) values:
+  // 0: absolute (close loop)
+  // 1 relative (close loop)
+  // 4 relative steps (open loop)
+  int hasEnc;
+  pC_->getIntegerParam(channel_, pC_->motorStatusHasEncoder_, &hasEnc);
+
+  if(hasEnc)
+  {
+   printf("MCS2Axis::move: closeloop: position: %g rel: %d\n",position,relative);
+
+    DBG_PRINTF("MCS2Axis::move: closeloop: position: %g rel: %d\n",position,relative);
     sprintf(pC_->outString_, ":CHAN%d:MMOD %d", channel_, relative > 0 ? 1 : 0);
     status = pC_->writeController();
     // Set acceleration
@@ -366,33 +376,33 @@ asynStatus MCS2Axis::move(double position, int relative, double minVelocity, dou
     sprintf(pC_->outString_, ":MOVE%d %f", channel_, position * PULSES_PER_STEP);
     status = pC_->writeController();
   }
-  else {
-    // open loop move
-    PositionType dtg = position - stepTarget_; // distance to go
-    stepTarget_ = (PositionType)position;      // store position in global scope
-    // Set mode; 4 == STEP
-    sprintf(pC_->outString_, ":CHAN%d:MMOD 4", channel_);
-    status = pC_->writeController();
-    // Set frequency; range 1..20000 Hz
-    unsigned short frequency = (unsigned short)maxVelocity;
-    if(frequency >= MAX_FREQUENCY) {
-      frequency = MAX_FREQUENCY;
-    }
-    sprintf(pC_->outString_, ":CHAN%d:STEP:FREQ %u", channel_, frequency);
-    status = pC_->writeController();
-    // Do move
-    sprintf(pC_->outString_, ":MOVE%d %lld", channel_, dtg);
-    status = pC_->writeController();
-    setDoubleParam(pC_->motorPosition_, (double)stepTarget_);
-  }
+  else
+  { // move relative in open loop
+    double curPos;
+    pC_->getDoubleParam(channel_, pC_->motorEncoderPosition_,&curPos);
+    //pC_->getDoubleParam(channel_, pC_->motorPosition_, &curPos);
+    if(!relative)
+      position=position-curPos;
+    curPos+=position;
+    DBG_PRINTF("MCS2Axis::move: openloop: new_pos: %g rel_move: %g\n",curPos,position);
+    //:STEP:FREQuency 1..20000, default:1000 Hz.
+    //:STEP:AMPLitude 1..65535, default:65535 (100 V).
+    setDoubleParam(pC_->motorEncoderPosition_, curPos);
+    setDoubleParam(pC_->motorPosition_, curPos);
 
+    sprintf(pC_->outString_, ":CHAN%d:MMOD %d", channel_, 4);
+    status = pC_->writeController();
+    DBG_PRINTF("MCS2Axis::move: %s ->status:%d\n",pC_->outString_,status);
+    sprintf(pC_->outString_, ":MOVE%d %f", channel_, position);
+    status = pC_->writeController();
+    DBG_PRINTF("MCS2Axis::move: %s ->status:%d\n",pC_->outString_,status);
+  }
   return status;
 }
 
 asynStatus MCS2Axis::home(double minVelocity, double maxVelocity, double acceleration, int forwards)
 {
   asynStatus status = asynSuccess;
-  printf("Home command received %d\n", forwards);
   unsigned short refOpt = 0;
 
   if (forwards==0){
@@ -401,13 +411,9 @@ asynStatus MCS2Axis::home(double minVelocity, double maxVelocity, double acceler
   refOpt |= AUTO_ZERO;
 
   // Set default reference options - direction and autozero
-  printf("ref opt: %d\n", refOpt);
   sprintf(pC_->outString_, ":CHAN%d:REF:OPT %d", channel_, refOpt);
-  status = pC_->writeController();
-  pC_->clearErrors();
+  DBG_PRINTF("MCS2Axis::home: %s",pC_->outString_);
 
-  // Set hold time
-  sprintf(pC_->outString_, ":CHAN%d:HOLD %d", channel_, HOLD_FOREVER);
   status = pC_->writeController();
   pC_->clearErrors();
   // Set acceleration
@@ -440,8 +446,8 @@ asynStatus MCS2Axis::setPosition(double position)
 {
   asynStatus status = asynSuccess;
 
-  printf("Set position receieved\n");
   sprintf(pC_->outString_, ":CHAN%d:POS %f", channel_, position * PULSES_PER_STEP);
+  DBG_PRINTF("MCS2Axis::setPosition: %s",pC_->outString_);
   status = pC_->writeController();
   return status;
 }
@@ -470,6 +476,7 @@ asynStatus MCS2Axis::poll(bool *moving)
   double theoryPosition;
   int driveOn;
   int mclf;
+  int hold;
   asynStatus comStatus = asynSuccess;
 
   // Read the channel state
@@ -487,12 +494,16 @@ asynStatus MCS2Axis::poll(bool *moving)
   followLimitReached = (chanState & FOLLOWING_LIMIT_REACHED) ? 1 : 0;
   movementFailed = (chanState & MOVEMENT_FAILED) ? 1 : 0;
   refMark = (chanState & REFERENCE_MARK) ? 1 : 0;
-
+  //if (channel_==0)
+  //{ //debug code
+  //  int hasEnc; pC_->getIntegerParam(channel_, pC_->motorStatusHasEncoder_, &hasEnc);
+  //  printf("chanState:0x%x hasEnc:%d closedLoop:%d\n",chanState,hasEnc,closedLoop);
+  //}
   *moving = done ? false : true;
+  //https://epics.anl.gov/bcda/synApps/motor/R7-2-1/motorRecord.html#Fields_status
   setIntegerParam(pC_->motorStatusDone_, done);
-  setIntegerParam(pC_->motorClosedLoop_, closedLoop);
   setIntegerParam(pC_->motorStatusHasEncoder_, sensorPresent);
-  setIntegerParam(pC_->motorStatusGainSupport_, sensorPresent);
+  setIntegerParam(pC_->motorStatusGainSupport_, closedLoop);
   setIntegerParam(pC_->motorStatusHomed_, isReferenced);
   setIntegerParam(pC_->motorStatusHighLimit_, endStopReached);
   setIntegerParam(pC_->motorStatusLowLimit_, endStopReached);
@@ -500,9 +511,10 @@ asynStatus MCS2Axis::poll(bool *moving)
   setIntegerParam(pC_->motorStatusProblem_, movementFailed);
   setIntegerParam(pC_->motorStatusAtHome_, refMark);
 
-  // Read the current encoder position, if the positioner has a sensor
-  sensorPresent_ = sensorPresent;
-  if(sensorPresent){
+  if (sensorPresent)
+  {
+    // avoid pollong POS? if there is no sensor present. This would not return a value and block the polling for 1-2 sec
+  // Read the current encoder position
     sprintf(pC_->outString_, ":CHAN%d:POS?", channel_);
     comStatus = pC_->writeReadController();
     if (comStatus) goto skip;
@@ -525,7 +537,6 @@ asynStatus MCS2Axis::poll(bool *moving)
   if (comStatus) goto skip;
   driveOn = atoi(pC_->inString_) ? 1 : 0;
   setIntegerParam(pC_->motorStatusPowerOn_, driveOn);
-  setIntegerParam(pC_->motorStatusProblem_, 0);
 
   // Read the currently selected positioner type
   sprintf(pC_->outString_, ":CHAN%d:PTYP?", channel_);
@@ -534,16 +545,20 @@ asynStatus MCS2Axis::poll(bool *moving)
   positionerType = atoi(pC_->inString_);
   setIntegerParam(pC_->ptyprb_, positionerType);
 
-  // Read CAL/REF status and MCLF when idle
+  // Read CAL status MCLF HOLD when idle
   if (done)
   {
     setIntegerParam(pC_->cal_, isCalibrated);
-    setIntegerParam(pC_->ref_, isReferenced);
     sprintf(pC_->outString_, ":CHAN%d:MCLF?", channel_);
     comStatus = pC_->writeReadController();
         if (comStatus) goto skip;
     mclf = atoi(pC_->inString_);
     setIntegerParam(pC_->mclf_, mclf);
+    sprintf(pC_->outString_, ":CHAN%d:HOLD?", channel_);
+    comStatus = pC_->writeReadController();
+        if (comStatus) goto skip;
+    hold = atoi(pC_->inString_);
+    setIntegerParam(pC_->hold_, hold);
   }
 
 skip:

--- a/smarActApp/src/smarActMCS2MotorDriver.cpp
+++ b/smarActApp/src/smarActMCS2MotorDriver.cpp
@@ -8,7 +8,6 @@ Jan 19, 2019
 
 */
 
-
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -27,19 +26,19 @@ Jan 19, 2019
 static const char *driverName = "SmarActMCS2MotorDriver";
 
 /** Creates a new MCS2Controller object.
-  * \param[in] portName             The name of the asyn port that will be created for this driver
-  * \param[in] MCS2PortName         The name of the drvAsynIPPPort that was created previously to connect to the MCS2 controller 
-  * \param[in] numAxes              The number of axes that this controller supports 
-  * \param[in] movingPollPeriod     The time between polls when any axis is moving 
-  * \param[in] idlePollPeriod       The time between polls when no axis is moving 
-  */
-MCS2Controller::MCS2Controller(const char *portName, const char *MCS2PortName, int numAxes, 
+ * \param[in] portName             The name of the asyn port that will be created for this driver
+ * \param[in] MCS2PortName         The name of the drvAsynIPPPort that was created previously to connect to the MCS2 controller
+ * \param[in] numAxes              The number of axes that this controller supports
+ * \param[in] movingPollPeriod     The time between polls when any axis is moving
+ * \param[in] idlePollPeriod       The time between polls when no axis is moving
+ */
+MCS2Controller::MCS2Controller(const char *portName, const char *MCS2PortName, int numAxes,
                                double movingPollPeriod, double idlePollPeriod, int unusedMask)
-  :  asynMotorController(portName, numAxes, NUM_MCS2_PARAMS, 
-                         0, 0,
-                         ASYN_CANBLOCK | ASYN_MULTIDEVICE, 
-                         1, // autoconnect
-                         0, 0)  // Default priority and stack size
+    : asynMotorController(portName, numAxes, NUM_MCS2_PARAMS,
+                          0, 0,
+                          ASYN_CANBLOCK | ASYN_MULTIDEVICE,
+                          1,    // autoconnect
+                          0, 0) // Default priority and stack size
 {
   int axis, axisMask = 0;
   asynStatus status;
@@ -50,20 +49,20 @@ MCS2Controller::MCS2Controller(const char *portName, const char *MCS2PortName, i
   createParam(MCS2MclfString, asynParamInt32, &this->mclf_);
   createParam(MCS2PtypString, asynParamInt32, &this->ptyp_);
   createParam(MCS2PtypRbString, asynParamInt32, &this->ptyprb_);
-  createParam(MCS2PstatString, asynParamInt32, &this->pstatrb_);   // whole positioner status word
+  createParam(MCS2PstatString, asynParamInt32, &this->pstatrb_); // whole positioner status word
   createParam(MCS2RefString, asynParamInt32, &this->ref_);
   createParam(MCS2CalString, asynParamInt32, &this->cal_);
 
-  /* Connect to MCS2 controller */
+  // Connect to MCS2 controller
   status = pasynOctetSyncIO->connect(MCS2PortName, 0, &pasynUserController_, NULL);
-  pasynOctetSyncIO->setInputEos (pasynUserController_, "\r\n", 2);
+  pasynOctetSyncIO->setInputEos(pasynUserController_, "\r\n", 2);
   pasynOctetSyncIO->setOutputEos(pasynUserController_, "\r\n", 2);
 
   asynPrint(this->pasynUserSelf, ASYN_TRACEIO_DRIVER, "MCS2Controller::MCS2Controller: Connecting to controller\n");
   if (status) {
-    asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, 
-      "%s:%s: cannot connect to MCS2 controller\n",
-      driverName, functionName);
+    asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
+              "%s:%s: cannot connect to MCS2 controller\n",
+              driverName, functionName);
   }
   asynPrint(this->pasynUserSelf, ASYN_TRACEIO_DRIVER, "MCS2Controller::MCS2Controller: Clearing error messages\n");
   this->clearErrors();
@@ -71,40 +70,38 @@ MCS2Controller::MCS2Controller(const char *portName, const char *MCS2PortName, i
   sprintf(this->outString_, ":DEV:SNUM?");
   status = this->writeReadController();
   if (status) {
-    asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, 
-      "%s:%s: cannot connect to MCS2 controller\n",
-      driverName, functionName);
+    asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
+              "%s:%s: cannot connect to MCS2 controller\n",
+              driverName, functionName);
   }
   asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, "MCS2Controller::MCS2Controller: Device Name: %s\n", this->inString_);
   this->clearErrors();
-
 
   // Create the axis objects
   asynPrint(this->pasynUserSelf, ASYN_TRACEIO_DRIVER, "MCS2Controller::MCS2Controller: Creating axes\n");
 
   for(axis=0; axis<numAxes; axis++){ 
     axisMask = (unusedMask & (1 << axis)) >> axis;
-    if(!axisMask)
-        new MCS2Axis(this, axis);
+    if (!axisMask)
+      new MCS2Axis(this, axis);
   }
 
   startPoller(movingPollPeriod, idlePollPeriod, 2);
 }
 
-
 /** Creates a new MCS2Controller object.
-  * Configuration command, called directly or from iocsh
-  * \param[in] portName          The name of the asyn port that will be created for this driver
-  * \param[in] MCS2PortName      The name of the drvAsynIPPPort that was created previously to connect to the MCS2 controller 
-  * \param[in] numAxes           The number of axes that this controller supports 
-  * \param[in] movingPollPeriod  The time in ms between polls when any axis is moving
-  * \param[in] idlePollPeriod    The time in ms between polls when no axis is moving 
-  */
-extern "C" int MCS2CreateController(const char *portName, const char *MCS2PortName, int numAxes, 
+ * Configuration command, called directly or from iocsh
+ * \param[in] portName          The name of the asyn port that will be created for this driver
+ * \param[in] MCS2PortName      The name of the drvAsynIPPPort that was created previously to connect to the MCS2 controller
+ * \param[in] numAxes           The number of axes that this controller supports
+ * \param[in] movingPollPeriod  The time in ms between polls when any axis is moving
+ * \param[in] idlePollPeriod    The time in ms between polls when no axis is moving
+ */
+extern "C" int MCS2CreateController(const char *portName, const char *MCS2PortName, int numAxes,
                                     int movingPollPeriod, int idlePollPeriod, int unusedMask)
 {
-  new MCS2Controller(portName, MCS2PortName, numAxes, movingPollPeriod/1000., idlePollPeriod/1000., unusedMask);
-  return(asynSuccess);
+  new MCS2Controller(portName, MCS2PortName, numAxes, movingPollPeriod / 1000., idlePollPeriod / 1000., unusedMask);
+  return (asynSuccess);
 }
 
 asynStatus MCS2Controller::clearErrors()
@@ -121,89 +118,88 @@ asynStatus MCS2Controller::clearErrors()
   if (comStatus) goto skip;
   numErrorMsgs = atoi(this->inString_);
   for (int i=0; i<numErrorMsgs; i++){
-	  sprintf(this->outString_, ":SYST:ERR?");
-	  comStatus = this->writeReadController();
+    sprintf(this->outString_, ":SYST:ERR?");
+    comStatus = this->writeReadController();
 	  if (comStatus) goto skip;
-	  printf("%s", this->inString_);
-	  errorCode = atoi(this->inString_);
+    printf("%s", this->inString_);
+    errorCode = atoi(this->inString_);
 	  switch (errorCode){
-		  case 259:		sprintf(errorMsg, "No sensor present");
-						break;
-		  case 34:		sprintf(errorMsg, "Invalid channel index");
-						break;
-		  case 0:		sprintf(errorMsg, "No error");
-						break;
-		  case -101:	sprintf(errorMsg, "Invalid character");
-						break;
-		  case -103:	sprintf(errorMsg, "Invalid seperator");
-						break;
-		  case -104:	sprintf(errorMsg, "Data type error");
-						break;
-		  case -108:	sprintf(errorMsg, "Parameter not allowed");
-						break;
-		  case -109:    sprintf(errorMsg, "Missing parameter");
-						break;
-		  case -113:	sprintf(errorMsg, "Command not exist");
-						break;
-		  case -151:	sprintf(errorMsg, "Invalid string");
-						break;
-		  case -350:	sprintf(errorMsg, "Queue overflow");
-						break;
-		  case -363:	sprintf(errorMsg, "Buffer overrun");
-						break;
-		  default:      sprintf(errorMsg, "Unable to decode %d", errorCode);
-						break;
-		}
-	  asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
-			  "MCS2Controller::clearErrors: %s\n", errorMsg);
+    case 259:    sprintf(errorMsg, "No sensor present");
+      break;
+    case 34:     sprintf(errorMsg, "Invalid channel index");
+      break;
+    case 0:      sprintf(errorMsg, "No error");
+      break;
+    case -101:   sprintf(errorMsg, "Invalid character");
+      break;
+    case -103:   sprintf(errorMsg, "Invalid seperator");
+      break;
+    case -104:   sprintf(errorMsg, "Data type error");
+      break;
+    case -108:   sprintf(errorMsg, "Parameter not allowed");
+      break;
+    case -109:   sprintf(errorMsg, "Missing parameter");
+      break;
+    case -113:   sprintf(errorMsg, "Command not exist");
+      break;
+    case -151:   sprintf(errorMsg, "Invalid string");
+      break;
+    case -350:   sprintf(errorMsg, "Queue overflow");
+      break;
+    case -363:   sprintf(errorMsg, "Buffer overrun");
+      break;
+    default:     sprintf(errorMsg, "Unable to decode %d", errorCode);
+      break;
+    }
+    asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
+              "MCS2Controller::clearErrors: %s\n", errorMsg);
   }
 
-  skip:
-  setIntegerParam(this->motorStatusProblem_, comStatus ? 1:0);
+skip:
+  setIntegerParam(this->motorStatusProblem_, comStatus ? 1 : 0);
   callParamCallbacks();
   return comStatus ? asynError : asynSuccess;
 }
 
-
 /** Reports on status of the driver
-  * \param[in] fp The file pointer on which report information will be written
-  * \param[in] level The level of report detail desired
-  *
-  * If details > 0 then information is printed about each axis.
-  * After printing controller-specific information calls asynMotorController::report()
-  */
+ * \param[in] fp The file pointer on which report information will be written
+ * \param[in] level The level of report detail desired
+ *
+ * If details > 0 then information is printed about each axis.
+ * After printing controller-specific information calls asynMotorController::report()
+ */
 void MCS2Controller::report(FILE *fp, int level)
 {
-  fprintf(fp, "MCS2 motor driver %s, numAxes=%d, moving poll period=%f, idle poll period=%f\n", 
-    this->portName, numAxes_, movingPollPeriod_, idlePollPeriod_);
+  fprintf(fp, "MCS2 motor driver %s, numAxes=%d, moving poll period=%f, idle poll period=%f\n",
+          this->portName, numAxes_, movingPollPeriod_, idlePollPeriod_);
 
   // Call the base class method
   asynMotorController::report(fp, level);
 }
 
 /** Returns a pointer to an MCS2MotorAxis object.
-  * Returns NULL if the axis number encoded in pasynUser is invalid.
-  * \param[in] pasynUser asynUser structure that encodes the axis index number. */
-MCS2Axis* MCS2Controller::getAxis(asynUser *pasynUser)
+ * Returns NULL if the axis number encoded in pasynUser is invalid.
+ * \param[in] pasynUser asynUser structure that encodes the axis index number. */
+MCS2Axis *MCS2Controller::getAxis(asynUser *pasynUser)
 {
-  return static_cast<MCS2Axis*>(asynMotorController::getAxis(pasynUser));
+  return static_cast<MCS2Axis *>(asynMotorController::getAxis(pasynUser));
 }
 
 /** Returns a pointer to an MCS2MotorAxis object.
-  * Returns NULL if the axis number encoded in pasynUser is invalid.
-  * \param[in] axisNo Axis index number. */
-MCS2Axis* MCS2Controller::getAxis(int axisNo)
+ * Returns NULL if the axis number encoded in pasynUser is invalid.
+ * \param[in] axisNo Axis index number. */
+MCS2Axis *MCS2Controller::getAxis(int axisNo)
 {
-  return static_cast<MCS2Axis*>(asynMotorController::getAxis(axisNo));
+  return static_cast<MCS2Axis *>(asynMotorController::getAxis(axisNo));
 }
 
 /** Called when asyn clients call pasynInt32->write().
-  * Extracts the function and axis number from pasynUser.
-  * Sets the value in the parameter library.
-  * For all other functions it calls asynMotorController::writeInt32.
-  * Calls any registered callbacks for this pasynUser->reason and address.
-  * \param[in] pasynUser asynUser structure that encodes the reason and address.
-  * \param[in] value     Value to write. */
+ * Extracts the function and axis number from pasynUser.
+ * Sets the value in the parameter library.
+ * For all other functions it calls asynMotorController::writeInt32.
+ * Calls any registered callbacks for this pasynUser->reason and address.
+ * \param[in] pasynUser asynUser structure that encodes the reason and address.
+ * \param[in] value     Value to write. */
 asynStatus MCS2Controller::writeInt32(asynUser *pasynUser, epicsInt32 value)
 {
   int function = pasynUser->reason;
@@ -211,7 +207,7 @@ asynStatus MCS2Controller::writeInt32(asynUser *pasynUser, epicsInt32 value)
   MCS2Axis *pAxis = getAxis(pasynUser);
   static const char *functionName = "writeInt32";
 
-  /* Check if axis exists */
+  // Check if axis exists
   if(!pAxis) return asynError;
 
   /* Set the parameter and readback in the parameter library.  This may be overwritten when we read back the
@@ -219,138 +215,136 @@ asynStatus MCS2Controller::writeInt32(asynUser *pasynUser, epicsInt32 value)
   status = setIntegerParam(pAxis->axisNo_, function, value);
 
   if (function == mclf_) {
-    /* set MCLF */
+    // set MCLF
     sprintf(pAxis->pC_->outString_, ":CHAN%d:MCLF:CURR %d", pAxis->axisNo_, value);
     status = pAxis->pC_->writeController();
   }
   else if (function == ptyp_) {
-    /* set positioner type */
+    // set positioner type
     sprintf(pAxis->pC_->outString_, ":CHAN%d:PTYP %d", pAxis->axisNo_, value);
     status = pAxis->pC_->writeController();
   }
   else if (function == cal_) {
-    /* send calibration command */
+    // send calibration command
     sprintf(pAxis->pC_->outString_, ":CAL%d", pAxis->axisNo_);
     status = pAxis->pC_->writeController();
   }
   else {
-    /* Call base class method */
+    // Call base class method
     status = asynMotorController::writeInt32(pasynUser, value);
   }
 
-  /* Do callbacks so higher layers see any changes */
+  // Do callbacks so higher layers see any changes
   callParamCallbacks(pAxis->axisNo_);
   if (status)
     asynPrint(pasynUser, ASYN_TRACE_ERROR,
-        "%s:%s: error, status=%d function=%d, value=%d\n",
-        driverName, functionName, status, function, value);
+              "%s:%s: error, status=%d function=%d, value=%d\n",
+              driverName, functionName, status, function, value);
   else
     asynPrint(pasynUser, ASYN_TRACEIO_DRIVER,
-        "%s:%s: function=%d, value=%d\n",
-        driverName, functionName, function, value);
+              "%s:%s: function=%d, value=%d\n",
+              driverName, functionName, function, value);
   return status;
 }
 
 // These are the MCS2Axis methods
 
 /** Creates a new MCS2Axis object.
-  * \param[in] pC Pointer to the ACRController to which this axis belongs. 
-  * \param[in] axisNo Index number of this axis, range 0 to pC->numAxes_-1.
-  * 
-  * Initializes register numbers, etc.
-  */
+ * \param[in] pC Pointer to the ACRController to which this axis belongs.
+ * \param[in] axisNo Index number of this axis, range 0 to pC->numAxes_-1.
+ *
+ * Initializes register numbers, etc.
+ */
 MCS2Axis::MCS2Axis(MCS2Controller *pC, int axisNo)
-  : asynMotorAxis(pC, axisNo),
-    pC_(pC)
+    : asynMotorAxis(pC, axisNo),
+      pC_(pC)
 {
-  asynStatus status;
+  // asynStatus status;
 
   asynPrint(pC->pasynUserSelf, ASYN_TRACEIO_DRIVER, "MCS2Axis::MCS2Axis: Creating axis %u\n", axisNo);
   channel_ = axisNo;
 
   // Set hold time
   sprintf(pC_->outString_, ":CHAN%d:HOLD %d", channel_, HOLD_FOREVER);
-  status = pC_->writeController();
+  /*status = */ pC_->writeController();
   pC_->clearErrors();
   callParamCallbacks();
 }
 
 /** Reports on status of the driver
-  * \param[in] fp The file pointer on which report information will be written
-  * \param[in] level The level of report detail desired
-  *
-  * If details > 0 then information is printed about each axis.
-  * After printing controller-specific information calls asynMotorController::report()
-  */
+ * \param[in] fp The file pointer on which report information will be written
+ * \param[in] level The level of report detail desired
+ *
+ * If details > 0 then information is printed about each axis.
+ * After printing controller-specific information calls asynMotorController::report()
+ */
 void MCS2Axis::report(FILE *fp, int level)
 {
   if (level > 0) {
-	int pcode;
-	char pname[256];
-	int channelState;
-	int vel;
-	int acc;
-	int mclf;
+    int pcode;
+    char pname[256];
+    int channelState;
+    int vel;
+    int acc;
+    int mclf;
     int followError;
-	int error;
-	int temp;
+    int error;
+    int temp;
 
-	asynStatus status;
+    asynStatus status;
 
-	sprintf(pC_->outString_, ":CHAN%d:PTYP?", channel_);
-	status = pC_->writeReadController();
-	pcode = atoi(pC_->inString_);
-	sprintf(pC_->outString_, ":CHAN%d:PTYP:NAME?", channel_);
-	status = pC_->writeReadController();
-	strcpy(pC_->inString_, pname);
-	sprintf(pC_->outString_, ":CHAN%d:STAT?", channel_);
-	status = pC_->writeReadController();
-	channelState = atoi(pC_->inString_);
-	sprintf(pC_->outString_, ":CHAN%d:VEL?", channel_);
-	status = pC_->writeReadController();
-	vel = atoi(pC_->inString_);
-	sprintf(pC_->outString_, ":CHAN%d:ACC?", channel_);
-	status = pC_->writeReadController();
-	acc = atoi(pC_->inString_);
-	sprintf(pC_->outString_, ":CHAN%d:MCLF?", channel_);
-	status = pC_->writeReadController();
-	mclf = atoi(pC_->inString_);
-	sprintf(pC_->outString_, ":CHAN%d:FERR?", channel_);
-	status = pC_->writeReadController();
-	followError = atoi(pC_->inString_);
-	sprintf(pC_->outString_, ":CHAN%d:ERR?", channel_);
-	status = pC_->writeReadController();
-	error = atoi(pC_->inString_);
-	sprintf(pC_->outString_, ":CHAN%d:TEMP?", channel_);
-	status = pC_->writeReadController();
-	temp = atoi(pC_->inString_);
+    sprintf(pC_->outString_, ":CHAN%d:PTYP?", channel_);
+    status = pC_->writeReadController();
+    pcode = atoi(pC_->inString_);
+    sprintf(pC_->outString_, ":CHAN%d:PTYP:NAME?", channel_);
+    status = pC_->writeReadController();
+    strcpy(pC_->inString_, pname);
+    sprintf(pC_->outString_, ":CHAN%d:STAT?", channel_);
+    status = pC_->writeReadController();
+    channelState = atoi(pC_->inString_);
+    sprintf(pC_->outString_, ":CHAN%d:VEL?", channel_);
+    status = pC_->writeReadController();
+    vel = atoi(pC_->inString_);
+    sprintf(pC_->outString_, ":CHAN%d:ACC?", channel_);
+    status = pC_->writeReadController();
+    acc = atoi(pC_->inString_);
+    sprintf(pC_->outString_, ":CHAN%d:MCLF?", channel_);
+    status = pC_->writeReadController();
+    mclf = atoi(pC_->inString_);
+    sprintf(pC_->outString_, ":CHAN%d:FERR?", channel_);
+    status = pC_->writeReadController();
+    followError = atoi(pC_->inString_);
+    sprintf(pC_->outString_, ":CHAN%d:ERR?", channel_);
+    status = pC_->writeReadController();
+    error = atoi(pC_->inString_);
+    sprintf(pC_->outString_, ":CHAN%d:TEMP?", channel_);
+    status = pC_->writeReadController();
+    temp = atoi(pC_->inString_);
 
-
-
+    if (status)
+      fprintf(fp, "  axis %d -> asyn status error %d\n", axisNo_, status);
     fprintf(fp, "  axis %d\n"
-			    " positioner type %d\n"
-				" positioner name %s\n"
-				" state %d\n"
-				" velocity %d\n"
-				" acceleration %d\n"
-				" max closed loop frequency %d\n"
-				" following error %d\n"
-				" error %d\n"
-				" temp %d\n",
+                "    positioner type %d\n"
+                "    positioner name %s\n"
+                "    state %d\n"
+                "    velocity %d\n"
+                "    acceleration %d\n"
+                "    max closed loop frequency %d\n"
+                "    following error %d\n"
+                "    error %d\n"
+                "    temp %d\n",
             axisNo_, pcode, pname, channelState, vel,
-			acc, mclf, followError, error, temp);
-	pC_->clearErrors();
+            acc, mclf, followError, error, temp);
+    pC_->clearErrors();
   }
 
   // Call the base class method
   asynMotorAxis::report(fp, level);
 }
 
-
 asynStatus MCS2Axis::move(double position, int relative, double minVelocity, double maxVelocity, double acceleration)
 {
   asynStatus status = asynSuccess;
-  static const char *functionName = "move";
 
   /* MCS2 move mode is:
    *	- absolute=0
@@ -371,10 +365,11 @@ asynStatus MCS2Axis::move(double position, int relative, double minVelocity, dou
     // Do move
     sprintf(pC_->outString_, ":MOVE%d %f", channel_, position * PULSES_PER_STEP);
     status = pC_->writeController();
-  } else {
+  }
+  else {
     // open loop move
-    PositionType dtg = position - stepTarget_;  // distance to go
-    stepTarget_ = (PositionType)position;       // store position in global scope
+    PositionType dtg = position - stepTarget_; // distance to go
+    stepTarget_ = (PositionType)position;      // store position in global scope
     // Set mode; 4 == STEP
     sprintf(pC_->outString_, ":CHAN%d:MMOD 4", channel_);
     status = pC_->writeController();
@@ -396,13 +391,12 @@ asynStatus MCS2Axis::move(double position, int relative, double minVelocity, dou
 
 asynStatus MCS2Axis::home(double minVelocity, double maxVelocity, double acceleration, int forwards)
 {
-  asynStatus status=asynSuccess;
-   static const char *functionName = "homeAxis";
+  asynStatus status = asynSuccess;
   printf("Home command received %d\n", forwards);
   unsigned short refOpt = 0;
 
   if (forwards==0){
-	  refOpt |= START_DIRECTION;
+    refOpt |= START_DIRECTION;
   }
   refOpt |= AUTO_ZERO;
 
@@ -417,11 +411,11 @@ asynStatus MCS2Axis::home(double minVelocity, double maxVelocity, double acceler
   status = pC_->writeController();
   pC_->clearErrors();
   // Set acceleration
-  sprintf(pC_->outString_, ":CHAN%d:ACC %f", channel_, acceleration*PULSES_PER_STEP);
+  sprintf(pC_->outString_, ":CHAN%d:ACC %f", channel_, acceleration * PULSES_PER_STEP);
   status = pC_->writeController();
   pC_->clearErrors();
   // Set velocity
-  sprintf(pC_->outString_, ":CHAN%d:VEL %f", channel_, maxVelocity*PULSES_PER_STEP);
+  sprintf(pC_->outString_, ":CHAN%d:VEL %f", channel_, maxVelocity * PULSES_PER_STEP);
   status = pC_->writeController();
   pC_->clearErrors();
   // Begin move
@@ -432,10 +426,9 @@ asynStatus MCS2Axis::home(double minVelocity, double maxVelocity, double acceler
   return status;
 }
 
-asynStatus MCS2Axis::stop(double acceleration )
+asynStatus MCS2Axis::stop(double acceleration)
 {
   asynStatus status;
-  static const char *functionName = "stopAxis";
 
   sprintf(pC_->outString_, ":STOP%d", channel_);
   status = pC_->writeController();
@@ -445,23 +438,23 @@ asynStatus MCS2Axis::stop(double acceleration )
 
 asynStatus MCS2Axis::setPosition(double position)
 {
-  asynStatus status=asynSuccess;
+  asynStatus status = asynSuccess;
 
   printf("Set position receieved\n");
-  sprintf(pC_->outString_, ":CHAN%d:POS %f", channel_, position*PULSES_PER_STEP);
+  sprintf(pC_->outString_, ":CHAN%d:POS %f", channel_, position * PULSES_PER_STEP);
   status = pC_->writeController();
   return status;
 }
 
 /** Polls the axis.
-  * This function reads the controller position, encoder position, the limit status, the moving status, 
-  * the drive power-on status and positioner type. It does not current detect following error, etc.
-  * but this could be added.
-  * It calls setIntegerParam() and setDoubleParam() for each item that it polls,
-  * and then calls callParamCallbacks() at the end.
-  * \param[out] moving A flag that is set indicating that the axis is moving (1) or done (0). */
+ * This function reads the controller position, encoder position, the limit status, the moving status,
+ * the drive power-on status and positioner type. It does not current detect following error, etc.
+ * but this could be added.
+ * It calls setIntegerParam() and setDoubleParam() for each item that it polls,
+ * and then calls callParamCallbacks() at the end.
+ * \param[out] moving A flag that is set indicating that the axis is moving (1) or done (0). */
 asynStatus MCS2Axis::poll(bool *moving)
-{ 
+{
   int done;
   int chanState;
   int closedLoop;
@@ -485,17 +478,17 @@ asynStatus MCS2Axis::poll(bool *moving)
   if (comStatus) goto skip;
   chanState = atoi(pC_->inString_);
   setIntegerParam(pC_->pstatrb_, chanState);
-  done               = (chanState & ACTIVELY_MOVING)?0:1;
-  closedLoop         = (chanState & CLOSED_LOOP_ACTIVE)?1:0;
-  sensorPresent      = (chanState & SENSOR_PRESENT)?1:0;
-  isCalibrated       = (chanState & IS_CALIBRATED)?1:0;
-  isReferenced       = (chanState & IS_REFERENCED)?1:0;
-  endStopReached     = (chanState & END_STOP_REACHED)?1:0;
-  followLimitReached = (chanState & FOLLOWING_LIMIT_REACHED)?1:0;
-  movementFailed     = (chanState & MOVEMENT_FAILED)?1:0;
-  refMark            = (chanState & REFERENCE_MARK)?1:0;
+  done = (chanState & ACTIVELY_MOVING) ? 0 : 1;
+  closedLoop = (chanState & CLOSED_LOOP_ACTIVE) ? 1 : 0;
+  sensorPresent = (chanState & SENSOR_PRESENT) ? 1 : 0;
+  isCalibrated = (chanState & IS_CALIBRATED) ? 1 : 0;
+  isReferenced = (chanState & IS_REFERENCED) ? 1 : 0;
+  endStopReached = (chanState & END_STOP_REACHED) ? 1 : 0;
+  followLimitReached = (chanState & FOLLOWING_LIMIT_REACHED) ? 1 : 0;
+  movementFailed = (chanState & MOVEMENT_FAILED) ? 1 : 0;
+  refMark = (chanState & REFERENCE_MARK) ? 1 : 0;
 
-  *moving = done ? false:true;
+  *moving = done ? false : true;
   setIntegerParam(pC_->motorStatusDone_, done);
   setIntegerParam(pC_->motorClosedLoop_, closedLoop);
   setIntegerParam(pC_->motorStatusHasEncoder_, sensorPresent);
@@ -530,7 +523,7 @@ asynStatus MCS2Axis::poll(bool *moving)
   sprintf(pC_->outString_, ":CHAN%d:AMPL?", channel_);
   comStatus = pC_->writeReadController();
   if (comStatus) goto skip;
-  driveOn = atoi(pC_->inString_) ? 1:0;
+  driveOn = atoi(pC_->inString_) ? 1 : 0;
   setIntegerParam(pC_->motorStatusPowerOn_, driveOn);
   setIntegerParam(pC_->motorStatusProblem_, 0);
 
@@ -542,19 +535,19 @@ asynStatus MCS2Axis::poll(bool *moving)
   setIntegerParam(pC_->ptyprb_, positionerType);
 
   // Read CAL/REF status and MCLF when idle
-  if(done)
+  if (done)
   {
-        setIntegerParam(pC_->cal_, isCalibrated);
-        setIntegerParam(pC_->ref_, isReferenced);
-        sprintf(pC_->outString_, ":CHAN%d:MCLF?", channel_);
-        comStatus = pC_->writeReadController();
+    setIntegerParam(pC_->cal_, isCalibrated);
+    setIntegerParam(pC_->ref_, isReferenced);
+    sprintf(pC_->outString_, ":CHAN%d:MCLF?", channel_);
+    comStatus = pC_->writeReadController();
         if (comStatus) goto skip;
-        mclf = atoi(pC_->inString_);
-        setIntegerParam(pC_->mclf_, mclf);
+    mclf = atoi(pC_->inString_);
+    setIntegerParam(pC_->mclf_, mclf);
   }
 
-  skip:
-  setIntegerParam(pC_->motorStatusProblem_, comStatus ? 1:0);
+skip:
+  setIntegerParam(pC_->motorStatusProblem_, comStatus ? 1 : 0);
   callParamCallbacks();
   return comStatus ? asynError : asynSuccess;
 }
@@ -566,12 +559,12 @@ static const iocshArg MCS2CreateControllerArg2 = {"Number of axes", iocshArgInt}
 static const iocshArg MCS2CreateControllerArg3 = {"Moving poll period (ms)", iocshArgInt};
 static const iocshArg MCS2CreateControllerArg4 = {"Idle poll period (ms)", iocshArgInt};
 static const iocshArg MCS2CreateControllerArg5 = {"Unused bit mask", iocshArgInt};
-static const iocshArg * const MCS2CreateControllerArgs[] = {&MCS2CreateControllerArg0,
-                                                            &MCS2CreateControllerArg1,
-                                                            &MCS2CreateControllerArg2,
-                                                            &MCS2CreateControllerArg3,
-                                                            &MCS2CreateControllerArg4,
-                                                            &MCS2CreateControllerArg5};
+static const iocshArg *const MCS2CreateControllerArgs[] = {&MCS2CreateControllerArg0,
+                                                           &MCS2CreateControllerArg1,
+                                                           &MCS2CreateControllerArg2,
+                                                           &MCS2CreateControllerArg3,
+                                                           &MCS2CreateControllerArg4,
+                                                           &MCS2CreateControllerArg5};
 static const iocshFuncDef MCS2CreateControllerDef = {"MCS2CreateController", 6, MCS2CreateControllerArgs};
 static void MCS2CreateContollerCallFunc(const iocshArgBuf *args)
 {
@@ -584,6 +577,5 @@ static void MCS2MotorRegister(void)
 }
 
 extern "C" {
-epicsExportRegistrar(MCS2MotorRegister);
+  epicsExportRegistrar(MCS2MotorRegister);
 }
-

--- a/smarActApp/src/smarActMCS2MotorDriver.h
+++ b/smarActApp/src/smarActMCS2MotorDriver.h
@@ -8,14 +8,14 @@ Jan 19, 2019
 
 Note:
 The MCS2 controller uses 64-bit int for the encoder and target positions. The motor record is limited
-to 32 bit int for RMP (https://github.com/epics-modules/motor/issues/8, 
+to 32 bit int for RMP (https://github.com/epics-modules/motor/issues/8,
 https://epics.anl.gov/tech-talk/2018/msg00087.php) which effectively limits the travel
-range to +/- 2.1mm. 
+range to +/- 2.1mm.
 Since it doesn't seem the motor record will update to using 64bit int the choices I can see are:
 * 1 - using a non-standard motor support
 * 2 - rescaling the minimum resolution to 1nm to effectively increase the range to 2.1m
 
-I chose option 2. 
+I chose option 2.
 1 step = 1nm
 
 Someone with more experience may have a better solution.
@@ -37,8 +37,6 @@ The two that may be of significant interest are:
  * rot: controller ndeg --> driver udeg. Because of this the user can use the positioner for deg ranges
  * If this scaling was not implemented the maximum range would be ~2.147 mm/deg, now it's ~2147 mm/deg */
 #define PULSES_PER_STEP 1000
-
-typedef long long PositionType;
 
 /** MCS2 Axis status flags **/
 const unsigned short ACTIVELY_MOVING         = 0x0001;
@@ -90,17 +88,18 @@ public:
   asynStatus setPosition(double position);
 
 private:
-  MCS2Controller *pC_;      /**< Pointer to the asynMotorController to which this axis belongs.
-                                *   Abbreviated because it is used very frequently */
+  MCS2Controller *pC_; /**< Pointer to the asynMotorController to which this axis belongs.
+                        *   Abbreviated because it is used very frequently */
   int channel_;
   int sensorPresent_;
   PositionType stepTarget_ = 0;
   asynStatus comStatus_;
 
-friend class MCS2Controller;
+  friend class MCS2Controller;
 };
 
-class epicsShareClass MCS2Controller : public asynMotorController {
+class epicsShareClass MCS2Controller : public asynMotorController
+{
 public:
   MCS2Controller(const char *portName, const char *MCS2PortName, int numAxes, double movingPollPeriod, double idlePollPeriod, int unusedMask = 0);
   virtual asynStatus clearErrors();
@@ -110,20 +109,19 @@ public:
 
   /* These are the methods that we override from asynMotorDriver */
   void report(FILE *fp, int level);
-  MCS2Axis* getAxis(asynUser *pasynUser);
-  MCS2Axis* getAxis(int axisNo);
+  MCS2Axis *getAxis(asynUser *pasynUser);
+  MCS2Axis *getAxis(int axisNo);
 
 protected:
   int mclf_; /**< MCL frequency */
 #define FIRST_MCS2_PARAM mclf_
-  int ptyp_; /**< positioner type */
-  int ptyprb_; /**< positioner type readback */
+  int ptyp_;    /**< positioner type */
+  int ptyprb_;  /**< positioner type readback */
   int pstatrb_; /**< positoner status word readback */
   int ref_;  /**< reference command */ 
-  int cal_;  /**< calibration command */
+  int cal_;     /**< calibration command */
 #define LAST_MCS2_PARAM cal_
 #define NUM_MCS2_PARAMS (&LAST_MCS2_PARAM - &FIRST_MCS2_PARAM + 1)
-  
-friend class MCS2Axis;
-};
 
+  friend class MCS2Axis;
+};

--- a/smarActApp/src/smarActMCS2MotorDriver.h
+++ b/smarActApp/src/smarActMCS2MotorDriver.h
@@ -63,16 +63,12 @@ const unsigned short   ABORT_ON_END_STOP       = 0x0008;
 const unsigned short   CONTINUE_ON_REF_FOUND   = 0x0010;
 const unsigned short   STOP_ON_REF_FOUND       = 0x0020;
 
-/** MCS2 Axis constants **/
-#define HOLD_FOREVER 0xffffffff
-#define MAX_FREQUENCY 20000
-
 /** drvInfo strings for extra parameters that the MCS2 controller supports */
-#define MCS2MclfString "MCLF"
 #define MCS2PtypString "PTYP"
 #define MCS2PtypRbString "PTYP_RB"
 #define MCS2PstatString "PSTAT"
-#define MCS2RefString "REF"
+#define MCS2MclfString "MCLF"
+#define MCS2HoldString "HOLD"
 #define MCS2CalString "CAL"
 
 class epicsShareClass MCS2Axis : public asynMotorAxis
@@ -91,9 +87,6 @@ private:
   MCS2Controller *pC_; /**< Pointer to the asynMotorController to which this axis belongs.
                         *   Abbreviated because it is used very frequently */
   int channel_;
-  int sensorPresent_;
-  PositionType stepTarget_ = 0;
-  asynStatus comStatus_;
 
   friend class MCS2Controller;
 };
@@ -113,12 +106,12 @@ public:
   MCS2Axis *getAxis(int axisNo);
 
 protected:
-  int mclf_; /**< MCL frequency */
-#define FIRST_MCS2_PARAM mclf_
   int ptyp_;    /**< positioner type */
+#define FIRST_MCS2_PARAM ptyp_
   int ptyprb_;  /**< positioner type readback */
   int pstatrb_; /**< positoner status word readback */
-  int ref_;  /**< reference command */ 
+  int mclf_;    /**< MCL frequency */
+  int hold_;    /**< hold time */
   int cal_;     /**< calibration command */
 #define LAST_MCS2_PARAM cal_
 #define NUM_MCS2_PARAMS (&LAST_MCS2_PARAM - &FIRST_MCS2_PARAM + 1)

--- a/smarActApp/src/smarActMCSMotorDriver.cpp
+++ b/smarActApp/src/smarActMCSMotorDriver.cpp
@@ -24,15 +24,18 @@
 #include <epicsExport.h>
 
 /* Static configuration parameters (compile-time constants) */
-#undef DEBUG
+#ifdef DEBUG
+  #define DBG_PRINTF(...) printf(__VA_ARGS__)
+#else
+  #define DBG_PRINTF(...)
+#endif
 
 #define CMD_LEN 50
 #define REP_LEN 50
 #define DEFLT_TIMEOUT 2.0
 
-#define HOLD_FOREVER 60000
-#define HOLD_NEVER       0
-#define FAR_AWAY     1000000000 /*nm*/
+#define FAR_AWAY_LIN 1000000000 /*nm*/
+#define FAR_AWAY_ROT 32767  /*revolutions*/
 #define UDEG_PER_REV 360000000
 
 #ifdef __MSC__
@@ -162,9 +165,8 @@ SmarActMCSController::SmarActMCSController(const char *portName, const char *IOP
                           0, // interrupt mask
                           ASYN_CANBLOCK | ASYN_MULTIDEVICE,
                           1,    // autoconnect
-                          0, 0) // default priority and stack size
-      ,
-      asynUserMot_p_(0)
+                          0, 0), // default priority and stack size
+       asynUserMot_p_(0)
 {
   asynStatus status;
   char junk[100];
@@ -174,6 +176,13 @@ SmarActMCSController::SmarActMCSController(const char *portName, const char *IOP
   disableSpeed_ = disableSpeed;
   if (disableSpeed_)
     epicsPrintf("SmarActMCSController(%s): WARNING - The speed set commands have been disabled for this controller\n", portName);
+
+  createParam(MCSPtypString, asynParamInt32, &this->ptyp_);
+  createParam(MCSPtypRbString, asynParamInt32, &this->ptyprb_);
+  createParam(MCSAutoZeroString, asynParamInt32, &this->autoZero_);
+  createParam(MCSHoldTimeString, asynParamInt32, &this->holdTime_);
+  createParam(MCSSclfString, asynParamInt32, &this->sclf_);
+  createParam(MCSCalString, asynParamInt32, &this->cal_);
 
   status = pasynOctetSyncIO->connect(IOPortName, 0, &asynUserMot_p_, NULL);
   if (status) {
@@ -218,8 +227,8 @@ SmarActMCSController::sendCmd(size_t *got_p, char *rep, int len, double timeout,
 
   status = pasynOctetSyncIO->writeRead(asynUserMot_p_, buf, strlen(buf), rep, len, timeout, &nwrite, got_p, &eomReason);
 
+  //DBG_PRINTF("SmarActMCSController::sendCmd: %s -> %d\n", buf,status);
   // asynPrint(c_p_->pasynUserSelf, ASYN_TRACEIO_DRIVER, "sendCmd()=%s", buf);
-
   return status;
 }
 
@@ -255,24 +264,84 @@ asynStatus SmarActMCSController::sendCmd(char *rep, int len, const char *fmt, ..
   return status;
 }
 
-/* Obtain value of the 'motorClosedLoop_' parameter (which
- * maps to the record's CNEN field)
- */
-int SmarActMCSAxis::getClosedLoop()
+/** Called when asyn clients call pasynInt32->write().
+ * Extracts the function and axis number from pasynUser.
+ * Sets the value in the parameter library.
+ * For all other functions it calls asynMotorController::writeInt32.
+ * Calls any registered callbacks for this pasynUser->reason and address.
+ * \param[in] pasynUser asynUser structure that encodes the reason and address.
+ * \param[in] value     Value to write. */
+asynStatus SmarActMCSController::writeInt32(asynUser *pasynUser, epicsInt32 value)
 {
-  int val;
-  c_p_->getIntegerParam(axisNo_, c_p_->motorClosedLoop_, &val);
-  return val;
+  int function = pasynUser->reason;
+  asynStatus status = asynSuccess;
+  char rep[REP_LEN];
+  int val, ax;
+  SmarActMCSAxis *pAxis = static_cast<SmarActMCSAxis *>(getAxis(pasynUser));
+
+  if (pAxis == NULL) {
+    asynPrint(pasynUser, ASYN_TRACE_ERROR,
+          "SmarActMCSController:writeInt32: error, function: %i. Invalid axis number.\n",
+          function);
+    return asynError;
+  }
+
+  /* Set the parameter and readback in the parameter library.  This may be overwritten when we read back the
+   * status at the end, but that's OK */
+  status = setIntegerParam(pAxis->axisNo_, function, value);
+
+  if (function == ptyp_) {
+    // set positioner type
+    status = sendCmd(rep, sizeof(rep), ":SST%i,%i", pAxis->channel_, value);
+    if (status) return status;
+    if (parseReply(rep, &ax, &val)) return asynError;
+    pAxis->checkType();
+  }
+  else if (function == cal_) {
+    // send calibration command
+    status = sendCmd(rep, sizeof(rep), ":CS%i", pAxis->channel_);
+    if (status) return status;
+    if (parseReply(rep, &ax, &val)) return asynError;
+  }
+  else if (function == sclf_) {
+    // set piezo MaxClockFreq
+    status = sendCmd(rep, sizeof(rep), ":SCLF%i,%i", pAxis->channel_, value);
+    if (status) return status;
+    if (parseReply(rep, &ax, &val)) return asynError;
+  }
+  else {
+    /* Call base class method */
+    status = asynMotorController::writeInt32(pasynUser, value);
+  }
+
+  /* Do callbacks so higher layers see any changes */
+  callParamCallbacks(pAxis->channel_);
+  if (status)
+    asynPrint(pasynUser, ASYN_TRACE_ERROR,
+          "SmarActMCSController:writeInt32: error, status=%d function=%d, value=%d\n",
+          status, function, value);
+  else
+    asynPrint(pasynUser, ASYN_TRACEIO_DRIVER,
+          "SmarActMCSController:writeInt32: function=%d, value=%d\n",
+          function, value);
+  return status;
 }
-/*
- * return 1 if encoder exists.
- * return 0 if encoder does not exist
+
+/* Check if the positioner type set on the controller
+ * is linear or rotary and set the isRot_ parameter correctly.
  */
-int SmarActMCSAxis::getEncoder()
+void SmarActMCSAxis::checkType()
 {
   int val;
-  c_p_->getIntegerParam(axisNo_, c_p_->motorStatusHasEncoder_, &val);
-  return val;
+  // Attempt to check linear position, if we receive
+  // an error, we're a rotary motor.
+  if ((comStatus_ = getVal("GP", &val))) {
+    isRot_ = 1;
+  }
+  else {
+    isRot_ = 0;
+  }
+  return;
 }
 
 SmarActMCSAxis::SmarActMCSAxis(class SmarActMCSController *cnt_p, int axis, int channel)
@@ -282,39 +351,23 @@ SmarActMCSAxis::SmarActMCSAxis(class SmarActMCSController *cnt_p, int axis, int 
   int angle;
   int rev;
   channel_ = channel;
-  stepCount_ = 0; // initialize open loop step count to 0. Does it need to be restored from auto save?
+
   asynPrint(c_p_->pasynUserSelf, ASYN_TRACEIO_DRIVER, "SmarActMCSAxis::SmarActMCSAxis -- creating axis %u\n", axis);
+
   if (c_p_->disableSpeed_)
     comStatus_ = asynSuccess;
   else
     comStatus_ = getVal("GCLS", &vel_);
-#ifdef DEBUG
-  printf("GCLS %u returned %i\n", axis, comStatus_);
-#endif
+  DBG_PRINTF("SmarActMCSAxis::SmarActMCSAxis: GCLS %u returned %i\n", axis, comStatus_);
   if (comStatus_)
     goto bail;
   if ((comStatus_ = getVal("GS", &val)))
     goto bail;
 
-  if (Holding == val) {
-    // still holding? This means that - in a previous life - the
-    // axis was configured for 'infinite holding'. Inherit this
-    // (until the next 'move' command that is).
-    ///
-    holdTime_ = HOLD_FOREVER;
-  }
-  else {
-    // initial value from 'closed-loop' property
-    holdTime_ = getClosedLoop() ? HOLD_FOREVER : 0;
-  }
+  setIntegerParam(c_p_->autoZero_, 1);
+  setIntegerParam(c_p_->holdTime_, 0);
 
-  // Attempt to check linear position, if we receive
-  // an error, we're a rotary motor.
-  isRot_ = 0;
-
-  if ((comStatus_ = getVal("GP", &val)))  {
-    isRot_ = 1;
-  }
+  checkType();
 
   // Query the sensor type
   if ((comStatus_ = getVal("GST", &sensorType_)))
@@ -389,32 +442,24 @@ SmarActMCSAxis::getAngle(int *val_p, int *rev_p)
 asynStatus
 SmarActMCSAxis::poll(bool *moving_p)
 {
-  int val;
-  int angle;
+  epicsInt32 pos;
+  epicsInt32 val;
+  epicsInt32 angle;
   int rev;
   enum SmarActMCSStatus status;
 
-  if (getEncoder())
-  {
-    if (isRot_)    {
-      if ((comStatus_ = getAngle(&angle, &rev)))
-        goto bail;
-      // Convert angle and revs to total angle
-      val = rev * UDEG_PER_REV + angle;
-    }
-    else {
-      if ((comStatus_ = getVal("GP", &val)))
-        goto bail;
-    }
+  if (isRot_){
+    if ((comStatus_ = getAngle(&angle, &rev)))
+      goto bail;
+    // Convert angle and revs to total angle
+    pos = rev * UDEG_PER_REV + angle;
   }
   else {
-    val = stepCount_;
+    if ((comStatus_ = getVal("GP", (int *)&pos)))
+      goto bail;
   }
-  setDoubleParam(c_p_->motorEncoderPosition_, (double)val);
-  setDoubleParam(c_p_->motorPosition_, (double)val);
-#ifdef DEBUG
-  printf("POLL (position %d)", val);
-#endif
+  setDoubleParam(c_p_->motorEncoderPosition_, (double)pos);
+  setDoubleParam(c_p_->motorPosition_, (double)pos);
 
   if ((comStatus_ = getVal("GS", &val)))
     goto bail;
@@ -422,19 +467,6 @@ SmarActMCSAxis::poll(bool *moving_p)
   status = (enum SmarActMCSStatus)val;
 
   switch (status) {
-  default:
-    *moving_p = false;
-    break;
-
-    /* If we use 'infinite' holding (until the next 'move' command)
-     * then the 'Holding' state must be considered 'not moving'. However,
-     * if we use a 'finite' holding time then we probably should consider
-     * the 'move' command incomplete until the holding time expires.
-     */
-  case Holding:
-    *moving_p = HOLD_FOREVER == holdTime_ ? false : true;
-    break;
-
   case Stepping:
   case Scanning:
   case Targeting:
@@ -442,6 +474,11 @@ SmarActMCSAxis::poll(bool *moving_p)
   case Calibrating:
   case FindRefMark:
     *moving_p = true;
+    break;
+
+  case Holding:
+  default:
+    *moving_p = false;
     break;
   }
 
@@ -455,18 +492,20 @@ SmarActMCSAxis::poll(bool *moving_p)
 
   setIntegerParam(c_p_->motorStatusHomed_, val ? 1 : 0);
 
-#ifdef DEBUG
-  printf(" status %u", status);
-#endif
+  // Get currently set positioner type
+  if ((comStatus_ = getVal("GST", &val)))
+    goto bail;
+  setIntegerParam(c_p_->ptyprb_, val);
+
+  if ((comStatus_ = getVal("GST", &val)))
+    goto bail;
 
 bail:
   setIntegerParam(c_p_->motorStatusProblem_, comStatus_ ? 1 : 0);
   setIntegerParam(c_p_->motorStatusCommsError_, comStatus_ ? 1 : 0);
-#ifdef DEBUG
-  printf("\n");
-#endif
 
   callParamCallbacks();
+  //DBG_PRINTF("SmarActMCSAxis::poll: position:%d status:%u", pos,status);
 
   return comStatus_;
 }
@@ -493,9 +532,6 @@ SmarActMCSAxis::moveCmd(const char *fmt, ...)
   }
 
 bail:
-#ifdef DEBUG
-  printf("\n");
-#endif
 
   return comStatus_;
 }
@@ -503,14 +539,14 @@ bail:
 asynStatus
 SmarActMCSAxis::setSpeed(double velocity)
 {
-  long vel;
+  epicsInt32 vel;
   asynStatus status;
 
   // ignore set speed commands if flag is set
   if (c_p_->disableSpeed_)
     return asynSuccess;
 
-  if ((vel = (long)rint(fabs(velocity))) != vel_) {
+  if ((vel = (epicsInt32)rint(fabs(velocity))) != vel_) {
     /* change speed */
     if (asynSuccess == (status = moveCmd(":SCLS%u,%ld", channel_, vel))) {
       vel_ = vel;
@@ -523,79 +559,43 @@ SmarActMCSAxis::setSpeed(double velocity)
 asynStatus
 SmarActMCSAxis::move(double position, int relative, double min_vel, double max_vel, double accel)
 {
+  int holdTime;
   const char *fmt_rot = relative ? ":MAR%u,%ld,%d,%d" : ":MAA%u,%ld,%d,%d";
   const char *fmt_lin = relative ? ":MPR%u,%ld,%d" : ":MPA%u,%ld,%d";
-  const char *fmt_step = ":MST%u,%ld,%d,%d"; // open loop move using step count, amplitude (0-4095; 0V-100V), frequency (1-18500 Hz)
   const char *fmt;
-  const int MAX_FREQ = 18500;                        // max allowed frequency
-  const int MAX_VOLTAGE = 100;                       // max voltage 100V
-  const double STEP_PER_VOLT = 4095.0 / MAX_VOLTAGE; // max voltage index, 4095=100V
-  double rpos;
-  long angle;
+  long int rpos;
+  epicsInt32 angle;
   int rev;
-#ifdef DEBUG
-  printf("Move to %f (speed %f - %f); accel %f\n", position, min_vel, max_vel, accel);
-#endif
-  if (getEncoder())
-  {
-    if (isRot_) {
-      fmt = fmt_rot;
-    }
-    else {
-      fmt = fmt_lin;
-    }
 
-    if ((comStatus_ = setSpeed(max_vel)))
-      goto bail;
-
-    /* cache 'closed-loop' setting until next move */
-    holdTime_ = getClosedLoop() ? HOLD_FOREVER : 0;
-
-    rpos = rint(position);
-
-    if (isRot_) {
-      angle = (long)rpos % UDEG_PER_REV;
-      rev = (int)(rpos / UDEG_PER_REV);
-      if (angle < 0) {
-        angle += UDEG_PER_REV;
-        rev -= 1;
-      }
-      comStatus_ = moveCmd(fmt, channel_, angle, rev, holdTime_);
-    }
-    else {
-      comStatus_ = moveCmd(fmt, channel_, (long)rpos, holdTime_);
-    }
+  if (isRot_) {
+    fmt = fmt_rot;
+  } else {
+    fmt = fmt_lin;
   }
-  else
-  {
-    fmt = fmt_step;
 
-    rpos = rint(position);
-    if (relative == 0) // absolute move
-    {
-      int diff = rpos - stepCount_;
-      stepCount_ = rpos;
-      rpos = diff; // subtract current step count to produce steps for this move
-    }
-    else
-    {
-      // relative move. the position value is the number of steps intended
-      stepCount_ += rpos;
-    }
-    // overload min_vel as amplitude
-    double piezoVoltage = (min_vel > MAX_VOLTAGE) ? (MAX_VOLTAGE) : ((min_vel < 1) ? (1) : (min_vel));
-    int amplitude = piezoVoltage * STEP_PER_VOLT;
-    // overload max_vel as frequency
-    int frequency = (max_vel > MAX_FREQ) ? (MAX_FREQ) : ((max_vel < 1) ? (1) : (max_vel));
+  DBG_PRINTF("SmarActMCSAxis::move: pos:%g min_vel:%g max_vel:%g\n", position, min_vel, max_vel);
 
-#ifdef DEBUG
-    printf("Open loop Step to %ld (piezo voltage %d ,frequency %d)\n", (long)rpos, amplitude, frequency);
-#endif
-    // overload accel as frequency
-    comStatus_ = moveCmd(fmt, channel_, (long)rpos, amplitude, frequency);
+  if ((comStatus_ = setSpeed(max_vel)))
+    goto bail;
+
+  rpos = lround(position);
+
+  c_p_->getIntegerParam(axisNo_, c_p_->holdTime_, &holdTime);
+
+  if (isRot_) {
+    angle = (epicsInt32)rpos % UDEG_PER_REV;
+    rev = (int)(rpos / UDEG_PER_REV);
+    if (angle < 0){
+      angle += UDEG_PER_REV;
+      rev -= 1;
+    }
+    comStatus_ = moveCmd(fmt, channel_, angle, rev, holdTime);
+  } else {
+    comStatus_ = moveCmd(fmt, channel_, rpos, holdTime);
   }
+
 bail:
-  if (comStatus_) {
+  if (comStatus_){
     setIntegerParam(c_p_->motorStatusProblem_, 1);
     setIntegerParam(c_p_->motorStatusCommsError_, 1);
     callParamCallbacks();
@@ -606,26 +606,17 @@ bail:
 asynStatus
 SmarActMCSAxis::home(double min_vel, double max_vel, double accel, int forwards)
 {
+  int holdTime;
+  int autoZero;
+  DBG_PRINTF("SmarActMCSAxis::home: forward:%u\n", forwards);
 
-#ifdef DEBUG
-  printf("Home %u\n", forwards);
-#endif
-  if (getEncoder())
-  {
+  if ((comStatus_ = setSpeed(max_vel)))
+    goto bail;
 
-    if ((comStatus_ = setSpeed(max_vel)))
-      goto bail;
+  c_p_->getIntegerParam(axisNo_, c_p_->autoZero_, &autoZero);
+  c_p_->getIntegerParam(axisNo_, c_p_->holdTime_, &holdTime);
 
-    // cache 'closed-loop' setting until next move
-    holdTime_ = getClosedLoop() ? HOLD_FOREVER : 0;
-
-    comStatus_ = moveCmd(":FRM%u,%u,%d,%d", channel_, forwards ? 0 : 1, holdTime_, isRot_ ? 1 : 0);
-  }
-  else
-  {
-    // no encoder, can't home. So just set current step count to 0
-    stepCount_ = 0;
-  }
+  comStatus_ = moveCmd(":FRM%u,%u,%d,%d", channel_, forwards ? 0 : 1, holdTime, autoZero);
 
 bail:
   if (comStatus_) {
@@ -639,9 +630,7 @@ bail:
 asynStatus
 SmarActMCSAxis::stop(double acceleration)
 {
-#ifdef DEBUG
-  printf("Stop\n");
-#endif
+  DBG_PRINTF("SmarActMCSAxis::stop:\n");
   comStatus_ = moveCmd(":S%u", channel_);
 
   if (comStatus_) {
@@ -658,25 +647,19 @@ SmarActMCSAxis::setPosition(double position)
   double rpos;
 
   rpos = rint(position);
-  if (getEncoder()) {
-    if (isRot_) {
-      // For rotation stages the revolution will always be set to zero
-      // Only set position if it is between zero an 360 degrees
-      if (rpos >= 0.0 && rpos < (double)UDEG_PER_REV) {
-        comStatus_ = moveCmd(":SP%u,%d", channel_, (long)rpos);
-      }
-      else {
-        comStatus_ = asynError;
-      }
+
+  if (isRot_){
+    // For rotation stages the revolution will always be set to zero
+    // Only set position if it is between zero an 360 degrees
+    if (rpos >= 0.0 && rpos < (double)UDEG_PER_REV) {
+      comStatus_ = moveCmd(":SP%u,%d", channel_, (epicsInt32)rpos);
+    } else {
+      comStatus_ = asynError;
     }
-    else {
-      comStatus_ = moveCmd(":SP%u,%d", channel_, (long)rpos);
-    }
+  } else {
+    comStatus_ = moveCmd(":SP%u,%d", channel_, (epicsInt32)rpos);
   }
-  else
-  {
-    stepCount_ = rpos;
-  }
+
   if (comStatus_) {
     setIntegerParam(c_p_->motorStatusProblem_, 1);
     setIntegerParam(c_p_->motorStatusCommsError_, 1);
@@ -688,18 +671,17 @@ SmarActMCSAxis::setPosition(double position)
 asynStatus
 SmarActMCSAxis::moveVelocity(double min_vel, double max_vel, double accel)
 {
-  long speed = (long)rint(fabs(max_vel));
-  long tgt_pos = FAR_AWAY;
+  epicsInt32 speed = (epicsInt32)rint(fabs(max_vel));
+  epicsInt32 tgt_pos;
+  signed char dir = 1;
 
   /* No MCS command we an use directly. Just use a 'relative move' to
    * very far target.
    */
 
-#ifdef DEBUG
-  printf("moveVelocity (%f - %f)\n", min_vel, max_vel);
-#endif
+  DBG_PRINTF("SmarActMCSAxis::moveVelocity: min_vel:%g max_vel:%g\n", min_vel, max_vel);
 
-  if (0 == speed) {
+  if (0 == speed){
     /* Here we are in a dilemma. If we set the MCS' speed to zero
      * then it will move at unlimited speed which is so fast that
      * 'JOG' makes no sense.
@@ -710,14 +692,20 @@ SmarActMCSAxis::moveVelocity(double min_vel, double max_vel, double accel)
     return asynSuccess;
   }
 
-  if (max_vel < 0) {
-    tgt_pos = -tgt_pos;
+  if (max_vel < 0){
+    dir = -1;
   }
 
   if ((comStatus_ = setSpeed(max_vel)))
     goto bail;
 
-  comStatus_ = moveCmd(":MPR%u,%ld,0", channel_, tgt_pos);
+  if (isRot_){
+    tgt_pos = FAR_AWAY_ROT * dir;
+    comStatus_ = moveCmd(":MAR%u,0,%ld,0", channel_, tgt_pos);
+  } else {
+    tgt_pos = FAR_AWAY_LIN * dir;
+    comStatus_ = moveCmd(":MPR%u,%ld,0", channel_, tgt_pos);
+  }
 
 bail:
   if (comStatus_) {
@@ -758,8 +746,7 @@ smarActMCSCreateController(
 #endif
     rval = new SmarActMCSController(motorPortName, ioPortName, numAxes, movingPollPeriod, idlePollPeriod, disableSpeed);
 #ifdef ASYN_CANDO_EXCEPTIONS
-  }
-  catch (SmarActMCSException &e) {
+  } catch (SmarActMCSException &e) {
     epicsPrintf("smarActMCSCreateController failed (exception caught):\n%s\n", e.what());
     rval = 0;
   }
@@ -830,8 +817,7 @@ smarActMCSCreateAxis(
     pC->unlock();
 
 #ifdef ASYN_CANDO_EXCEPTIONS
-  }
-  catch (SmarActMCSException &e) {
+  } catch (SmarActMCSException &e) {
     epicsPrintf("SmarActMCSAxis failed (exception caught):\n%s\n", e.what());
     rval = 0;
   }

--- a/smarActApp/src/smarActMCSMotorDriver.cpp
+++ b/smarActApp/src/smarActMCSMotorDriver.cpp
@@ -24,7 +24,7 @@
 #include <epicsExport.h>
 
 /* Static configuration parameters (compile-time constants) */
-#undef  DEBUG
+#undef DEBUG
 
 #define CMD_LEN 50
 #define REP_LEN 50
@@ -37,68 +37,72 @@
 
 #ifdef __MSC__
 /* MSC may not have rint() function */
-#if(_MSC_VER < 1900)
+#if (_MSC_VER < 1900)
 static double rint(double x)
 {
-  //middle value point test
-  if (ceil(x+0.5) == floor(x+0.5))
+  // middle value point test
+  if (ceil(x + 0.5) == floor(x + 0.5))
   {
     int a = (int)ceil(x);
-    if (a%2 == 0) return ceil(x);
-    else return floor(x);
+    if (a % 2 == 0)
+      return ceil(x);
+    else
+      return floor(x);
   }
-  else return floor(x+0.5);
+  else
+    return floor(x + 0.5);
 }
 #endif
 #endif
 
 /* The asyn motor driver apparently can't cope with exceptions */
-#undef  ASYN_CANDO_EXCEPTIONS
+#undef ASYN_CANDO_EXCEPTIONS
 /* Define this if exceptions should be thrown and it is OK to abort the application */
-#undef  DO_THROW_EXCEPTIONS
+#undef DO_THROW_EXCEPTIONS
 
 #if defined(ASYN_CANDO_EXCEPTIONS) || defined(DO_THROW_EXCEPTIONS)
 #define THROW_(e) throw e
 #else
-#define THROW_(e) epicsPrintf("%s\n",e.what());
+#define THROW_(e) epicsPrintf("%s\n", e.what());
 #endif
 
 enum SmarActMCSStatus {
-	Stopped     = 0,
-	Stepping    = 1,
-	Scanning    = 2,
-	Holding     = 3,
-	Targeting   = 4,
-	MoveDelay   = 5,
-	Calibrating = 6,
-	FindRefMark = 7,
-	Locked      = 9
+  Stopped     = 0,
+  Stepping    = 1,
+  Scanning    = 2,
+  Holding     = 3,
+  Targeting   = 4,
+  MoveDelay   = 5,
+  Calibrating = 6,
+  FindRefMark = 7,
+  Locked = 9
 };
 
 SmarActMCSException::SmarActMCSException(SmarActMCSExceptionType t, const char *fmt, ...)
-	: t_(t)
+  : t_(t)
 {
-va_list ap;
-	if ( fmt ) {
-		va_start(ap, fmt);
-		epicsVsnprintf(str_, sizeof(str_), fmt, ap);
-		va_end(ap);
-	} else {
-		str_[0] = 0;
-	}
+  va_list ap;
+  if (fmt) {
+    va_start(ap, fmt);
+    epicsVsnprintf(str_, sizeof(str_), fmt, ap);
+    va_end(ap);
+  }
+  else {
+    str_[0] = 0;
+  }
 };
 
 SmarActMCSException::SmarActMCSException(SmarActMCSExceptionType t, const char *fmt, va_list ap)
-		: t_(t)
+  : t_(t)
 {
-	epicsVsnprintf(str_, sizeof(str_), fmt, ap);
+  epicsVsnprintf(str_, sizeof(str_), fmt, ap);
 }
 
 /* Parse reply from MCS and return the value converted to a number.
  *
  * If the string cannot be parsed, i.e., is not in the format
  *  ':' , <string_of_upper_case_letters> , <number1> , ',' , <number2>
- * 
+ *
  * then the routine returns '-1'.
  *
  * Otherwise, if <string_of_upper_case_letters> starts with 'E'
@@ -114,20 +118,19 @@ SmarActMCSException::SmarActMCSException(SmarActMCSExceptionType t, const char *
  *       - return code zero    -> successful ACK or command reply; value
  *                                in *val_p.
  */
-int
-SmarActMCSController::parseReply(const char *reply, int *ax_p, int *val_p)
+int SmarActMCSController::parseReply(const char *reply, int *ax_p, int *val_p)
 {
-char cmd[10];
-	if ( 3 != sscanf(reply, ":%10[A-Z]%i,%i", cmd, ax_p, val_p) )
-		return -1;
-	return 'E' == cmd[0] ? *val_p : 0;
+  char cmd[10];
+  if (3 != sscanf(reply, ":%10[A-Z]%i,%i", cmd, ax_p, val_p))
+    return -1;
+  return 'E' == cmd[0] ? *val_p : 0;
 }
 
 /* Parse angle from MCS and return the value converted to a number.
  *
  * If the string cannot be parsed, i.e., is not in the format
  *  ':' , <string_of_upper_case_letters> , <number1> , ',' , <number2> , ',' , <number3>
- * 
+ *
  * then the routine returns '-1'.
  *
  * Otherwise, if <string_of_upper_case_letters> starts with 'E'
@@ -143,115 +146,113 @@ char cmd[10];
  *       - return code zero    -> successful ACK or command reply; value
  *                                in *val_p.
  */
-int
-SmarActMCSController::parseAngle(const char *reply, int *ax_p, int *val_p, int *rot_p)
+int SmarActMCSController::parseAngle(const char *reply, int *ax_p, int *val_p, int *rot_p)
 {
-char cmd[10];
-	if ( 4 != sscanf(reply, ":%10[A-Z]%i,%i,%i", cmd, ax_p, val_p, rot_p) )
-		return -1;
-	// Will this ever get called? An error response fewer values than an angle response
-	return 'E' == cmd[0] ? *val_p : 0;
+  char cmd[10];
+  if (4 != sscanf(reply, ":%10[A-Z]%i,%i,%i", cmd, ax_p, val_p, rot_p))
+    return -1;
+  // Will this ever get called? An error response fewer values than an angle response
+  return 'E' == cmd[0] ? *val_p : 0;
 }
 
 SmarActMCSController::SmarActMCSController(const char *portName, const char *IOPortName, int numAxes, double movingPollPeriod, double idlePollPeriod, int disableSpeed)
-	: asynMotorController(portName, numAxes,
-	                      0, // parameters
-	                      0, // interface mask
-	                      0, // interrupt mask
-	                      ASYN_CANBLOCK | ASYN_MULTIDEVICE,
-	                      1, // autoconnect
-	                      0,0) // default priority and stack size
-	, asynUserMot_p_(0)
+    : asynMotorController(portName, numAxes,
+                          0, // parameters
+                          0, // interface mask
+                          0, // interrupt mask
+                          ASYN_CANBLOCK | ASYN_MULTIDEVICE,
+                          1,    // autoconnect
+                          0, 0) // default priority and stack size
+      ,
+      asynUserMot_p_(0)
 {
-asynStatus       status;
-char             junk[100];
-size_t           got_junk;
-int              eomReason;
-pAxes_ = (SmarActMCSAxis **)(asynMotorController::pAxes_);
-disableSpeed_ = disableSpeed;
-if (disableSpeed_)
-	epicsPrintf("SmarActMCSController(%s): WARNING - The speed set commands have been disabled for this controller\n", portName);
+  asynStatus status;
+  char junk[100];
+  size_t got_junk;
+  int eomReason;
+  pAxes_ = (SmarActMCSAxis **)(asynMotorController::pAxes_);
+  disableSpeed_ = disableSpeed;
+  if (disableSpeed_)
+    epicsPrintf("SmarActMCSController(%s): WARNING - The speed set commands have been disabled for this controller\n", portName);
 
-	status = pasynOctetSyncIO->connect(IOPortName, 0, &asynUserMot_p_, NULL);
-	if ( status ) {
-		asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
-		          "SmarActMCSController:SmarActMCSController: cannot connect to MCS controller\n");
-		THROW_(SmarActMCSException(MCSConnectionError, "SmarActMCSController: unable to connect serial channel"));
-	}
+  status = pasynOctetSyncIO->connect(IOPortName, 0, &asynUserMot_p_, NULL);
+  if (status) {
+    asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
+          "SmarActMCSController:SmarActMCSController: cannot connect to MCS controller\n");
+    THROW_(SmarActMCSException(MCSConnectionError, "SmarActMCSController: unable to connect serial channel"));
+  }
 
-	// slurp away any initial telnet negotiation; there is no guarantee that
-	// the other end will not send some telnet chars in the future. The terminal
-	// server should really be configured to 'raw' mode!
-	pasynOctetSyncIO->read(asynUserMot_p_, junk, sizeof(junk), 2.0, &got_junk, &eomReason);
-	if ( got_junk ) {
-		epicsPrintf("SmarActMCSController(%s): WARNING - detected unexpected characters on link (%s); make sure you have a RAW (not TELNET) connection\n", portName, IOPortName);
-	}
+  // slurp away any initial telnet negotiation; there is no guarantee that
+  // the other end will not send some telnet chars in the future. The terminal
+  // server should really be configured to 'raw' mode!
+  pasynOctetSyncIO->read(asynUserMot_p_, junk, sizeof(junk), 2.0, &got_junk, &eomReason);
+  if (got_junk) {
+    epicsPrintf("SmarActMCSController(%s): WARNING - detected unexpected characters on link (%s); make sure you have a RAW (not TELNET) connection\n", portName, IOPortName);
+  }
 
-	pasynOctetSyncIO->setInputEos ( asynUserMot_p_, "\n", 1 );
-	pasynOctetSyncIO->setOutputEos( asynUserMot_p_, "\n", 1 );
+  pasynOctetSyncIO->setInputEos(asynUserMot_p_, "\n", 1);
+  pasynOctetSyncIO->setOutputEos(asynUserMot_p_, "\n", 1);
 
-	// Create axes
-/*	for ( ax=0; ax<numAxes; ax++ ) {
-		//axis_p = new SmarActMCSAxis(this, ax);
-		pAxes_[ax] = new SmarActMCSAxis(this, ax);
-	}
-*/
-	// move to iocsh function smarActMCSCreateAxis()
+  // Create axes
+  /*	for ( ax=0; ax<numAxes; ax++ ) {
+      //axis_p = new SmarActMCSAxis(this, ax);
+      pAxes_[ax] = new SmarActMCSAxis(this, ax);
+    }
+  */
+  // move to iocsh function smarActMCSCreateAxis()
 
-	// FIXME the 'forcedFastPolls' may need to be set if the 'sleep/wakeup' feature
-	//       of the sensor/readback is used.
-	startPoller( movingPollPeriod, idlePollPeriod, 0 );
-
+  // FIXME the 'forcedFastPolls' may need to be set if the 'sleep/wakeup' feature
+  //       of the sensor/readback is used.
+  startPoller(movingPollPeriod, idlePollPeriod, 0);
 }
 
 asynStatus
 SmarActMCSController::sendCmd(size_t *got_p, char *rep, int len, double timeout, const char *fmt, va_list ap)
 {
-char       buf[CMD_LEN];
-size_t     nwrite;
-int        eomReason;
-asynStatus status;
+  char buf[CMD_LEN];
+  size_t nwrite;
+  int eomReason;
+  asynStatus status;
 
-	epicsVsnprintf(buf, sizeof(buf), fmt, ap);
+  epicsVsnprintf(buf, sizeof(buf), fmt, ap);
 
-	status = pasynOctetSyncIO->writeRead( asynUserMot_p_, buf, strlen(buf), rep, len, timeout, &nwrite, got_p, &eomReason);
+  status = pasynOctetSyncIO->writeRead(asynUserMot_p_, buf, strlen(buf), rep, len, timeout, &nwrite, got_p, &eomReason);
 
-	//asynPrint(c_p_->pasynUserSelf, ASYN_TRACEIO_DRIVER, "sendCmd()=%s", buf);
+  // asynPrint(c_p_->pasynUserSelf, ASYN_TRACEIO_DRIVER, "sendCmd()=%s", buf);
 
-	return status;
+  return status;
 }
 
 asynStatus
 SmarActMCSController::sendCmd(size_t *got_p, char *rep, int len, double timeout, const char *fmt, ...)
 {
-va_list    ap;
-asynStatus status;
-	va_start(ap, fmt);
-	status = sendCmd(got_p, rep, len, timeout, fmt, ap);
-	va_end(ap);
-	return status;
+  va_list ap;
+  asynStatus status;
+  va_start(ap, fmt);
+  status = sendCmd(got_p, rep, len, timeout, fmt, ap);
+  va_end(ap);
+  return status;
 }
-
 
 asynStatus SmarActMCSController::sendCmd(size_t *got_p, char *rep, int len, const char *fmt, ...)
 {
-va_list    ap;
-asynStatus status;
-	va_start(ap, fmt);
-	status = sendCmd(got_p, rep, len, DEFLT_TIMEOUT, fmt, ap);
-	va_end(ap);
-	return status;
+  va_list ap;
+  asynStatus status;
+  va_start(ap, fmt);
+  status = sendCmd(got_p, rep, len, DEFLT_TIMEOUT, fmt, ap);
+  va_end(ap);
+  return status;
 }
 
 asynStatus SmarActMCSController::sendCmd(char *rep, int len, const char *fmt, ...)
 {
-va_list    ap;
-asynStatus status;
-size_t     got;
-	va_start(ap, fmt);
-	status = sendCmd(&got, rep, len, DEFLT_TIMEOUT, fmt, ap);
-	va_end(ap);
-	return status;
+  va_list ap;
+  asynStatus status;
+  size_t got;
+  va_start(ap, fmt);
+  status = sendCmd(&got, rep, len, DEFLT_TIMEOUT, fmt, ap);
+  va_end(ap);
+  return status;
 }
 
 /* Obtain value of the 'motorClosedLoop_' parameter (which
@@ -259,85 +260,84 @@ size_t     got;
  */
 int SmarActMCSAxis::getClosedLoop()
 {
-int val;
-	c_p_->getIntegerParam(axisNo_, c_p_->motorClosedLoop_, &val);
-	return val;
+  int val;
+  c_p_->getIntegerParam(axisNo_, c_p_->motorClosedLoop_, &val);
+  return val;
 }
 /*
- * return 1 if encoder exists. 
+ * return 1 if encoder exists.
  * return 0 if encoder does not exist
  */
 int SmarActMCSAxis::getEncoder()
 {
-	int val;
-	c_p_->getIntegerParam(axisNo_, c_p_->motorStatusHasEncoder_, &val);
-	return val;
+  int val;
+  c_p_->getIntegerParam(axisNo_, c_p_->motorStatusHasEncoder_, &val);
+  return val;
 }
 
 SmarActMCSAxis::SmarActMCSAxis(class SmarActMCSController *cnt_p, int axis, int channel)
-	: asynMotorAxis(cnt_p, axis), c_p_(cnt_p)
+  : asynMotorAxis(cnt_p, axis), c_p_(cnt_p)
 {
-	int val;
-	int angle;
-	int rev;
-	channel_ = channel;
-	stepCount_ = 0; // initialize open loop step count to 0. Does it need to be restored from auto save?
-	asynPrint(c_p_->pasynUserSelf, ASYN_TRACEIO_DRIVER, "SmarActMCSAxis::SmarActMCSAxis -- creating axis %u\n", axis);
-	if (c_p_->disableSpeed_)
-		comStatus_ = asynSuccess;
-	else
-		comStatus_ = getVal("GCLS",&vel_);
+  int val;
+  int angle;
+  int rev;
+  channel_ = channel;
+  stepCount_ = 0; // initialize open loop step count to 0. Does it need to be restored from auto save?
+  asynPrint(c_p_->pasynUserSelf, ASYN_TRACEIO_DRIVER, "SmarActMCSAxis::SmarActMCSAxis -- creating axis %u\n", axis);
+  if (c_p_->disableSpeed_)
+    comStatus_ = asynSuccess;
+  else
+    comStatus_ = getVal("GCLS", &vel_);
 #ifdef DEBUG
-	printf("GCLS %u returned %i\n", axis, comStatus_);
+  printf("GCLS %u returned %i\n", axis, comStatus_);
 #endif
-	if ( comStatus_ )
-		goto bail;
-	if ( (comStatus_ = getVal("GS", &val)) )
-		goto bail;
+  if (comStatus_)
+    goto bail;
+  if ((comStatus_ = getVal("GS", &val)))
+    goto bail;
 
-	if ( Holding == val ) {
-		// still holding? This means that - in a previous life - the
-		// axis was configured for 'infinite holding'. Inherit this
-		// (until the next 'move' command that is).
-		///
-		holdTime_ = HOLD_FOREVER;
-	} else {
-		// initial value from 'closed-loop' property
-		holdTime_ = getClosedLoop() ? HOLD_FOREVER : 0;
-	}
+  if (Holding == val) {
+    // still holding? This means that - in a previous life - the
+    // axis was configured for 'infinite holding'. Inherit this
+    // (until the next 'move' command that is).
+    ///
+    holdTime_ = HOLD_FOREVER;
+  }
+  else {
+    // initial value from 'closed-loop' property
+    holdTime_ = getClosedLoop() ? HOLD_FOREVER : 0;
+  }
 
-	// Attempt to check linear position, if we receive
-	// an error, we're a rotary motor.
-	isRot_ = 0;
+  // Attempt to check linear position, if we receive
+  // an error, we're a rotary motor.
+  isRot_ = 0;
 
-	if ( (comStatus_ = getVal("GP", &val)) ) {
-		isRot_ = 1;
-	}
+  if ((comStatus_ = getVal("GP", &val)))  {
+    isRot_ = 1;
+  }
 
-        // Query the sensor type
-	if ( (comStatus_ = getVal("GST", &sensorType_)) )
-		goto bail;
+  // Query the sensor type
+  if ((comStatus_ = getVal("GST", &sensorType_)))
+    goto bail;
 
-	if (isRot_ == 1 && asynSuccess == getAngle(&angle, &rev) ) {
-		setIntegerParam(c_p_->motorStatusHasEncoder_, 1);
-		setIntegerParam(c_p_->motorStatusGainSupport_, 1);
-	}
-	else if (isRot_ == 0 &&  asynSuccess == getVal("GP",&val) ) {
-		setIntegerParam(c_p_->motorStatusHasEncoder_, 1);
-		setIntegerParam(c_p_->motorStatusGainSupport_, 1);
-	}
-
+  if (isRot_ == 1 && asynSuccess == getAngle(&angle, &rev)) {
+    setIntegerParam(c_p_->motorStatusHasEncoder_, 1);
+    setIntegerParam(c_p_->motorStatusGainSupport_, 1);
+  }
+  else if (isRot_ == 0 && asynSuccess == getVal("GP", &val)) {
+    setIntegerParam(c_p_->motorStatusHasEncoder_, 1);
+    setIntegerParam(c_p_->motorStatusGainSupport_, 1);
+  }
 
 bail:
-	setIntegerParam(c_p_->motorStatusProblem_, comStatus_ ? 1 : 0 );
-	setIntegerParam(c_p_->motorStatusCommsError_, comStatus_ ? 1 : 0 );
+  setIntegerParam(c_p_->motorStatusProblem_, comStatus_ ? 1 : 0);
+  setIntegerParam(c_p_->motorStatusCommsError_, comStatus_ ? 1 : 0);
 
-	callParamCallbacks();
+  callParamCallbacks();
 
-	if ( comStatus_ ) {
-		THROW_(SmarActMCSException(MCSCommunicationError, "SmarActMCSAxis::SmarActMCSAxis -- channel %u ASYN error %i", axis, comStatus_));
-	}
-
+  if (comStatus_) {
+    THROW_(SmarActMCSException(MCSCommunicationError, "SmarActMCSAxis::SmarActMCSAxis -- channel %u ASYN error %i", axis, comStatus_));
+  }
 }
 
 /* Read a parameter from the MCS (nothing to do with asyn's parameter
@@ -351,17 +351,17 @@ bail:
 asynStatus
 SmarActMCSAxis::getVal(const char *parm_cmd, int *val_p)
 {
-char       rep[REP_LEN];
-asynStatus st;
-int        ax;
+  char rep[REP_LEN];
+  asynStatus st;
+  int ax;
 
-	//asynPrint(c_p_->pasynUserSelf, ASYN_TRACEIO_DRIVER, "getVal() cmd=:%s%u", parm_cmd, this->channel_);
+  // asynPrint(c_p_->pasynUserSelf, ASYN_TRACEIO_DRIVER, "getVal() cmd=:%s%u", parm_cmd, this->channel_);
 
-	//st = c_p_->sendCmd(rep, sizeof(rep), ":%s%u", parm_cmd, this->axisNo_);
-	st = c_p_->sendCmd(rep, sizeof(rep), ":%s%u", parm_cmd, this->channel_);
-	if ( st )
-		return st;
-	return c_p_->parseReply(rep, &ax, val_p) ? asynError: asynSuccess;
+  // st = c_p_->sendCmd(rep, sizeof(rep), ":%s%u", parm_cmd, this->axisNo_);
+  st = c_p_->sendCmd(rep, sizeof(rep), ":%s%u", parm_cmd, this->channel_);
+  if (st)
+    return st;
+  return c_p_->parseReply(rep, &ax, val_p) ? asynError : asynSuccess;
 }
 
 /* Read the position of rotation stage
@@ -374,235 +374,233 @@ int        ax;
 asynStatus
 SmarActMCSAxis::getAngle(int *val_p, int *rev_p)
 {
-char       rep[REP_LEN];
-asynStatus st;
-int        ax;
+  char rep[REP_LEN];
+  asynStatus st;
+  int ax;
 
-	//asynPrint(c_p_->pasynUserSelf, ASYN_TRACEIO_DRIVER, "getAngle() cmd=:%s%u", parm_cmd, this->channel_);
+  // asynPrint(c_p_->pasynUserSelf, ASYN_TRACEIO_DRIVER, "getAngle() cmd=:%s%u", parm_cmd, this->channel_);
 
-	st = c_p_->sendCmd(rep, sizeof(rep), ":GA%u", this->channel_);
-	if ( st )
-		return st;
-	return c_p_->parseAngle(rep, &ax, val_p, rev_p) ? asynError: asynSuccess;
+  st = c_p_->sendCmd(rep, sizeof(rep), ":GA%u", this->channel_);
+  if (st)
+    return st;
+  return c_p_->parseAngle(rep, &ax, val_p, rev_p) ? asynError : asynSuccess;
 }
 
 asynStatus
-SmarActMCSAxis::poll(bool* moving_p)
+SmarActMCSAxis::poll(bool *moving_p)
 {
-	int                    val;
-	int                    angle;
-	int                    rev;
-	enum SmarActMCSStatus status;
+  int val;
+  int angle;
+  int rev;
+  enum SmarActMCSStatus status;
 
-	if (getEncoder())
-	{
-		if (isRot_) {
-			if ((comStatus_ = getAngle(&angle, &rev)))
-				goto bail;
-			// Convert angle and revs to total angle
-			val = rev * UDEG_PER_REV + angle;
-		}
-		else {
-			if ((comStatus_ = getVal("GP", &val)))
-				goto bail;
-		}
-	}
-	else {
-		val = stepCount_;
-	}
-	setDoubleParam(c_p_->motorEncoderPosition_, (double)val);
-	setDoubleParam(c_p_->motorPosition_, (double)val);
+  if (getEncoder())
+  {
+    if (isRot_)    {
+      if ((comStatus_ = getAngle(&angle, &rev)))
+        goto bail;
+      // Convert angle and revs to total angle
+      val = rev * UDEG_PER_REV + angle;
+    }
+    else {
+      if ((comStatus_ = getVal("GP", &val)))
+        goto bail;
+    }
+  }
+  else {
+    val = stepCount_;
+  }
+  setDoubleParam(c_p_->motorEncoderPosition_, (double)val);
+  setDoubleParam(c_p_->motorPosition_, (double)val);
 #ifdef DEBUG
-	printf("POLL (position %d)", val);
+  printf("POLL (position %d)", val);
 #endif
 
-	if ((comStatus_ = getVal("GS", &val)))
-		goto bail;
+  if ((comStatus_ = getVal("GS", &val)))
+    goto bail;
 
-	status = (enum SmarActMCSStatus)val;
+  status = (enum SmarActMCSStatus)val;
 
-	switch (status) {
-	default:
-		*moving_p = false;
-		break;
+  switch (status) {
+  default:
+    *moving_p = false;
+    break;
 
-		/* If we use 'infinite' holding (until the next 'move' command)
-		 * then the 'Holding' state must be considered 'not moving'. However,
-		 * if we use a 'finite' holding time then we probably should consider
-		 * the 'move' command incomplete until the holding time expires.
-		 */
-	case Holding:
-		*moving_p = HOLD_FOREVER == holdTime_ ? false : true;
-		break;
+    /* If we use 'infinite' holding (until the next 'move' command)
+     * then the 'Holding' state must be considered 'not moving'. However,
+     * if we use a 'finite' holding time then we probably should consider
+     * the 'move' command incomplete until the holding time expires.
+     */
+  case Holding:
+    *moving_p = HOLD_FOREVER == holdTime_ ? false : true;
+    break;
 
-	case Stepping:
-	case Scanning:
-	case Targeting:
-	case MoveDelay:
-	case Calibrating:
-	case FindRefMark:
-		*moving_p = true;
-		break;
-	}
+  case Stepping:
+  case Scanning:
+  case Targeting:
+  case MoveDelay:
+  case Calibrating:
+  case FindRefMark:
+    *moving_p = true;
+    break;
+  }
 
-	setIntegerParam(c_p_->motorStatusDone_, !*moving_p);
+  setIntegerParam(c_p_->motorStatusDone_, !*moving_p);
 
+  /* Check if the sensor 'knows' absolute position and
+   * update the MSTA 'HOMED' bit.
+   */
+  if ((comStatus_ = getVal("GPPK", &val)))
+    goto bail;
 
-	/* Check if the sensor 'knows' absolute position and
-	 * update the MSTA 'HOMED' bit.
-	 */
-	if ((comStatus_ = getVal("GPPK", &val)))
-		goto bail;
-
-	setIntegerParam(c_p_->motorStatusHomed_, val ? 1 : 0);
+  setIntegerParam(c_p_->motorStatusHomed_, val ? 1 : 0);
 
 #ifdef DEBUG
-	printf(" status %u", status);
+  printf(" status %u", status);
 #endif
 
 bail:
-	setIntegerParam(c_p_->motorStatusProblem_, comStatus_ ? 1 : 0);
-	setIntegerParam(c_p_->motorStatusCommsError_, comStatus_ ? 1 : 0);
+  setIntegerParam(c_p_->motorStatusProblem_, comStatus_ ? 1 : 0);
+  setIntegerParam(c_p_->motorStatusCommsError_, comStatus_ ? 1 : 0);
 #ifdef DEBUG
-	printf("\n");
+  printf("\n");
 #endif
 
-	callParamCallbacks();
+  callParamCallbacks();
 
-	return comStatus_;
+  return comStatus_;
 }
 
 asynStatus
 SmarActMCSAxis::moveCmd(const char *fmt, ...)
 {
-int     val, ax;
-char    rep[REP_LEN];
-size_t  got;
-double  tout = DEFLT_TIMEOUT;
-va_list ap;
+  int val, ax;
+  char rep[REP_LEN];
+  size_t got;
+  double tout = DEFLT_TIMEOUT;
+  va_list ap;
 
-	va_start(ap, fmt);
-	comStatus_ = c_p_->sendCmd(&got, rep, sizeof(rep), tout, fmt, ap);
-	va_end(ap);
+  va_start(ap, fmt);
+  comStatus_ = c_p_->sendCmd(&got, rep, sizeof(rep), tout, fmt, ap);
+  va_end(ap);
 
-	if ( comStatus_ )
-		goto bail;
+  if (comStatus_)
+    goto bail;
 
-	if ( c_p_->parseReply(rep, &ax, &val) ) {
-		comStatus_ = asynError;
-		goto bail;
-	}
+  if (c_p_->parseReply(rep, &ax, &val)) {
+    comStatus_ = asynError;
+    goto bail;
+  }
 
 bail:
 #ifdef DEBUG
-	printf("\n");
+  printf("\n");
 #endif
 
-	return comStatus_;
+  return comStatus_;
 }
 
 asynStatus
 SmarActMCSAxis::setSpeed(double velocity)
 {
-long       vel;
-asynStatus status;
+  long vel;
+  asynStatus status;
 
-	//ignore set speed commands if flag is set
-	if(c_p_->disableSpeed_)
-		return asynSuccess;
+  // ignore set speed commands if flag is set
+  if (c_p_->disableSpeed_)
+    return asynSuccess;
 
-	if ( (vel = (long)rint(fabs(velocity))) != vel_ ) {
-		/* change speed */
-		if ( asynSuccess == (status = moveCmd(":SCLS%u,%ld", channel_, vel)) ) {
-			vel_ = vel;
-		}
-		return status;
-	}
-	return asynSuccess;
+  if ((vel = (long)rint(fabs(velocity))) != vel_) {
+    /* change speed */
+    if (asynSuccess == (status = moveCmd(":SCLS%u,%ld", channel_, vel))) {
+      vel_ = vel;
+    }
+    return status;
+  }
+  return asynSuccess;
 }
 
 asynStatus
 SmarActMCSAxis::move(double position, int relative, double min_vel, double max_vel, double accel)
 {
-	const char* fmt_rot = relative ? ":MAR%u,%ld,%d,%d" : ":MAA%u,%ld,%d,%d";
-	const char* fmt_lin = relative ? ":MPR%u,%ld,%d" : ":MPA%u,%ld,%d";
-	const char* fmt_step = ":MST%u,%ld,%d,%d"; // open loop move using step count, amplitude (0-4095; 0V-100V), frequency (1-18500 Hz)
-	const char* fmt;
-	const int MAX_FREQ = 18500; // max allowed frequency
-	const int MAX_VOLTAGE = 100; // max voltage 100V
-	const double STEP_PER_VOLT = 4095.0/MAX_VOLTAGE; // max voltage index, 4095=100V
-	double rpos;
-	long angle;
-	int rev;
+  const char *fmt_rot = relative ? ":MAR%u,%ld,%d,%d" : ":MAA%u,%ld,%d,%d";
+  const char *fmt_lin = relative ? ":MPR%u,%ld,%d" : ":MPA%u,%ld,%d";
+  const char *fmt_step = ":MST%u,%ld,%d,%d"; // open loop move using step count, amplitude (0-4095; 0V-100V), frequency (1-18500 Hz)
+  const char *fmt;
+  const int MAX_FREQ = 18500;                        // max allowed frequency
+  const int MAX_VOLTAGE = 100;                       // max voltage 100V
+  const double STEP_PER_VOLT = 4095.0 / MAX_VOLTAGE; // max voltage index, 4095=100V
+  double rpos;
+  long angle;
+  int rev;
 #ifdef DEBUG
-		printf("Move to %f (speed %f - %f); accel %f\n", position, min_vel, max_vel, accel);
+  printf("Move to %f (speed %f - %f); accel %f\n", position, min_vel, max_vel, accel);
 #endif
-	if (getEncoder())
-	{
-		if (isRot_) {
-			fmt = fmt_rot;
-		}
-		else {
-			fmt = fmt_lin;
-		}
+  if (getEncoder())
+  {
+    if (isRot_) {
+      fmt = fmt_rot;
+    }
+    else {
+      fmt = fmt_lin;
+    }
 
+    if ((comStatus_ = setSpeed(max_vel)))
+      goto bail;
 
-		if ((comStatus_ = setSpeed(max_vel)))
-			goto bail;
+    /* cache 'closed-loop' setting until next move */
+    holdTime_ = getClosedLoop() ? HOLD_FOREVER : 0;
 
-		/* cache 'closed-loop' setting until next move */
-		holdTime_ = getClosedLoop() ? HOLD_FOREVER : 0;
+    rpos = rint(position);
 
-		rpos = rint(position);
+    if (isRot_) {
+      angle = (long)rpos % UDEG_PER_REV;
+      rev = (int)(rpos / UDEG_PER_REV);
+      if (angle < 0) {
+        angle += UDEG_PER_REV;
+        rev -= 1;
+      }
+      comStatus_ = moveCmd(fmt, channel_, angle, rev, holdTime_);
+    }
+    else {
+      comStatus_ = moveCmd(fmt, channel_, (long)rpos, holdTime_);
+    }
+  }
+  else
+  {
+    fmt = fmt_step;
 
-		if (isRot_) {
-			angle = (long)rpos % UDEG_PER_REV;
-			rev = (int)(rpos / UDEG_PER_REV);
-			if (angle < 0) {
-				angle += UDEG_PER_REV;
-				rev -= 1;
-			}
-			comStatus_ = moveCmd(fmt, channel_, angle, rev, holdTime_);
-		}
-		else {
-			comStatus_ = moveCmd(fmt, channel_, (long)rpos, holdTime_);
-		}
-	}
-	else
-	{
-		fmt = fmt_step;
-
-		rpos = rint(position);
-		if (relative == 0 ) // absolute move
-		{
-			int diff = rpos - stepCount_;
-			stepCount_ = rpos;
-			rpos = diff; // subtract current step count to produce steps for this move
-		}
-		else
-		{
-			// relative move. the position value is the number of steps intended
-			stepCount_ += rpos;
-		}
-		// overload min_vel as amplitude
-		double piezoVoltage = (min_vel > MAX_VOLTAGE) ? (MAX_VOLTAGE) : ((min_vel < 1) ? (1) : (min_vel));
-		int amplitude = piezoVoltage * STEP_PER_VOLT;
-		// overload max_vel as frequency
-		int frequency = (max_vel> MAX_FREQ) ? (MAX_FREQ) : ((max_vel< 1) ? (1) : (max_vel));
+    rpos = rint(position);
+    if (relative == 0) // absolute move
+    {
+      int diff = rpos - stepCount_;
+      stepCount_ = rpos;
+      rpos = diff; // subtract current step count to produce steps for this move
+    }
+    else
+    {
+      // relative move. the position value is the number of steps intended
+      stepCount_ += rpos;
+    }
+    // overload min_vel as amplitude
+    double piezoVoltage = (min_vel > MAX_VOLTAGE) ? (MAX_VOLTAGE) : ((min_vel < 1) ? (1) : (min_vel));
+    int amplitude = piezoVoltage * STEP_PER_VOLT;
+    // overload max_vel as frequency
+    int frequency = (max_vel > MAX_FREQ) ? (MAX_FREQ) : ((max_vel < 1) ? (1) : (max_vel));
 
 #ifdef DEBUG
-		printf("Open loop Step to %ld (piezo voltage %d ,frequency %d)\n", (long)rpos, amplitude, frequency);
+    printf("Open loop Step to %ld (piezo voltage %d ,frequency %d)\n", (long)rpos, amplitude, frequency);
 #endif
-		// overload accel as frequency
-		comStatus_ = moveCmd(fmt, channel_, (long)rpos, amplitude, frequency);
-	}
+    // overload accel as frequency
+    comStatus_ = moveCmd(fmt, channel_, (long)rpos, amplitude, frequency);
+  }
 bail:
-	if (comStatus_) {
-		setIntegerParam(c_p_->motorStatusProblem_, 1);
-		setIntegerParam(c_p_->motorStatusCommsError_, 1);
-		callParamCallbacks();
-	}
-	return comStatus_;
+  if (comStatus_) {
+    setIntegerParam(c_p_->motorStatusProblem_, 1);
+    setIntegerParam(c_p_->motorStatusCommsError_, 1);
+    callParamCallbacks();
+  }
+  return comStatus_;
 }
 
 asynStatus
@@ -610,182 +608,182 @@ SmarActMCSAxis::home(double min_vel, double max_vel, double accel, int forwards)
 {
 
 #ifdef DEBUG
-	printf("Home %u\n", forwards);
+  printf("Home %u\n", forwards);
 #endif
-	if (getEncoder())
-	{
-	
-		if ( (comStatus_ = setSpeed(max_vel)) )
-			goto bail;
+  if (getEncoder())
+  {
 
-		/* cache 'closed-loop' setting until next move */
-		holdTime_  = getClosedLoop() ? HOLD_FOREVER : 0;
+    if ((comStatus_ = setSpeed(max_vel)))
+      goto bail;
 
-		comStatus_ = moveCmd(":FRM%u,%u,%d,%d", channel_, forwards ? 0 : 1, holdTime_, isRot_ ? 1 : 0);
-	}
-	else
-	{
-		// no encoder, can't home. So just set current step count to 0
-		stepCount_ = 0;
-	}
+    // cache 'closed-loop' setting until next move
+    holdTime_ = getClosedLoop() ? HOLD_FOREVER : 0;
+
+    comStatus_ = moveCmd(":FRM%u,%u,%d,%d", channel_, forwards ? 0 : 1, holdTime_, isRot_ ? 1 : 0);
+  }
+  else
+  {
+    // no encoder, can't home. So just set current step count to 0
+    stepCount_ = 0;
+  }
 
 bail:
-	if ( comStatus_ ) {
-		setIntegerParam(c_p_->motorStatusProblem_, 1);
-		setIntegerParam(c_p_->motorStatusCommsError_, 1);
-		callParamCallbacks();
-	}
-	return comStatus_;
+  if (comStatus_) {
+    setIntegerParam(c_p_->motorStatusProblem_, 1);
+    setIntegerParam(c_p_->motorStatusCommsError_, 1);
+    callParamCallbacks();
+  }
+  return comStatus_;
 }
 
 asynStatus
 SmarActMCSAxis::stop(double acceleration)
 {
 #ifdef DEBUG
-	printf("Stop\n");
+  printf("Stop\n");
 #endif
-	comStatus_ = moveCmd(":S%u", channel_);
+  comStatus_ = moveCmd(":S%u", channel_);
 
-	if ( comStatus_ ) {
-		setIntegerParam(c_p_->motorStatusProblem_, 1);
-		setIntegerParam(c_p_->motorStatusCommsError_, 1);
-		callParamCallbacks();
-	}
-	return comStatus_;
+  if (comStatus_) {
+    setIntegerParam(c_p_->motorStatusProblem_, 1);
+    setIntegerParam(c_p_->motorStatusCommsError_, 1);
+    callParamCallbacks();
+  }
+  return comStatus_;
 }
 
 asynStatus
 SmarActMCSAxis::setPosition(double position)
 {
-	double rpos;
+  double rpos;
 
-	rpos = rint(position);
-	if (getEncoder()) {
-		if (isRot_) {
-			// For rotation stages the revolution will always be set to zero
-			// Only set position if it is between zero an 360 degrees
-			if (rpos >= 0.0 && rpos < (double)UDEG_PER_REV) {
-				comStatus_ = moveCmd(":SP%u,%d", channel_, (long)rpos);
-			}
-			else {
-				comStatus_ = asynError;
-			}
-		}
-		else {
-			comStatus_ = moveCmd(":SP%u,%d", channel_, (long)rpos);
-		}
-	}
-	else
-	{
-		stepCount_ = rpos;
-	}
-	if ( comStatus_ ) {
-		setIntegerParam(c_p_->motorStatusProblem_,    1);
-		setIntegerParam(c_p_->motorStatusCommsError_, 1);
-		callParamCallbacks();
-	}
-	return comStatus_;
+  rpos = rint(position);
+  if (getEncoder()) {
+    if (isRot_) {
+      // For rotation stages the revolution will always be set to zero
+      // Only set position if it is between zero an 360 degrees
+      if (rpos >= 0.0 && rpos < (double)UDEG_PER_REV) {
+        comStatus_ = moveCmd(":SP%u,%d", channel_, (long)rpos);
+      }
+      else {
+        comStatus_ = asynError;
+      }
+    }
+    else {
+      comStatus_ = moveCmd(":SP%u,%d", channel_, (long)rpos);
+    }
+  }
+  else
+  {
+    stepCount_ = rpos;
+  }
+  if (comStatus_) {
+    setIntegerParam(c_p_->motorStatusProblem_, 1);
+    setIntegerParam(c_p_->motorStatusCommsError_, 1);
+    callParamCallbacks();
+  }
+  return comStatus_;
 }
 
 asynStatus
 SmarActMCSAxis::moveVelocity(double min_vel, double max_vel, double accel)
 {
-long       speed   = (long)rint(fabs(max_vel));
-long       tgt_pos = FAR_AWAY;
+  long speed = (long)rint(fabs(max_vel));
+  long tgt_pos = FAR_AWAY;
 
-	/* No MCS command we an use directly. Just use a 'relative move' to
-	 * very far target.
-	 */
+  /* No MCS command we an use directly. Just use a 'relative move' to
+   * very far target.
+   */
 
 #ifdef DEBUG
-	printf("moveVelocity (%f - %f)\n", min_vel, max_vel);
+  printf("moveVelocity (%f - %f)\n", min_vel, max_vel);
 #endif
 
-	if ( 0 == speed ) {
-		/* Here we are in a dilemma. If we set the MCS' speed to zero
-		 * then it will move at unlimited speed which is so fast that
-		 * 'JOG' makes no sense.
-		 * Just 'STOP' the motion - hope that works...
-		 */
-		setIntegerParam(c_p_->motorStop_, 1);
-		callParamCallbacks();
-		return asynSuccess;
-	}
+  if (0 == speed) {
+    /* Here we are in a dilemma. If we set the MCS' speed to zero
+     * then it will move at unlimited speed which is so fast that
+     * 'JOG' makes no sense.
+     * Just 'STOP' the motion - hope that works...
+     */
+    setIntegerParam(c_p_->motorStop_, 1);
+    callParamCallbacks();
+    return asynSuccess;
+  }
 
-	if ( max_vel < 0 ) {
-		tgt_pos = -tgt_pos; 
-	}
+  if (max_vel < 0) {
+    tgt_pos = -tgt_pos;
+  }
 
-	if ( (comStatus_ = setSpeed(max_vel)) )
-		goto bail;
+  if ((comStatus_ = setSpeed(max_vel)))
+    goto bail;
 
-	comStatus_ = moveCmd(":MPR%u,%ld,0", channel_, tgt_pos);
+  comStatus_ = moveCmd(":MPR%u,%ld,0", channel_, tgt_pos);
 
 bail:
-	if ( comStatus_ ) {
-		setIntegerParam(c_p_->motorStatusProblem_, 1);
-		setIntegerParam(c_p_->motorStatusCommsError_, 1);
-		callParamCallbacks();
-	}
-	return comStatus_;
+  if (comStatus_) {
+    setIntegerParam(c_p_->motorStatusProblem_, 1);
+    setIntegerParam(c_p_->motorStatusCommsError_, 1);
+    callParamCallbacks();
+  }
+  return comStatus_;
 }
 
 /* iocsh wrapping and registration business (stolen from ACRMotorDriver.cpp) */
-static const iocshArg cc_a0 = {"Port name [string]",               iocshArgString};
-static const iocshArg cc_a1 = {"I/O port name [string]",           iocshArgString};
-static const iocshArg cc_a2 = {"Number of axes [int]",             iocshArgInt};
-static const iocshArg cc_a3 = {"Moving poll period (s) [double]",  iocshArgDouble};
-static const iocshArg cc_a4 = {"Idle poll period (s) [double]",    iocshArgDouble};
-static const iocshArg cc_a5 = {"Disable speed cmds [int]",         iocshArgInt};
+static const iocshArg cc_a0 = {"Port name [string]", iocshArgString};
+static const iocshArg cc_a1 = {"I/O port name [string]", iocshArgString};
+static const iocshArg cc_a2 = {"Number of axes [int]", iocshArgInt};
+static const iocshArg cc_a3 = {"Moving poll period (s) [double]", iocshArgDouble};
+static const iocshArg cc_a4 = {"Idle poll period (s) [double]", iocshArgDouble};
+static const iocshArg cc_a5 = {"Disable speed cmds [int]", iocshArgInt};
 
-static const iocshArg * const cc_as[] = {&cc_a0, &cc_a1, &cc_a2, &cc_a3, &cc_a4, &cc_a5};
+static const iocshArg *const cc_as[] = {&cc_a0, &cc_a1, &cc_a2, &cc_a3, &cc_a4, &cc_a5};
 
-static const iocshFuncDef cc_def = {"smarActMCSCreateController", sizeof(cc_as)/sizeof(cc_as[0]), cc_as};
+static const iocshFuncDef cc_def = {"smarActMCSCreateController", sizeof(cc_as) / sizeof(cc_as[0]), cc_as};
 
 extern "C" void *
 smarActMCSCreateController(
-	const char *motorPortName,
-	const char *ioPortName,
-	int         numAxes,
-	double      movingPollPeriod,
-	double      idlePollPeriod,
-	int			disableSpeed)
+  const char *motorPortName,
+  const char *ioPortName,
+  int numAxes,
+  double movingPollPeriod,
+  double idlePollPeriod,
+  int disableSpeed)
 {
-void *rval = 0;
-	// the asyn stuff doesn't seem to be prepared for exceptions. I get segfaults
-	// if constructing a controller (or axis) incurs an exception even if its
-	// caught (IMHO asyn should behave as if the controller/axis never existed...)
+  void *rval = 0;
+  // the asyn stuff doesn't seem to be prepared for exceptions. I get segfaults
+  // if constructing a controller (or axis) incurs an exception even if its
+  // caught (IMHO asyn should behave as if the controller/axis never existed...)
 #ifdef ASYN_CANDO_EXCEPTIONS
-	try {
+  try {
 #endif
-		rval = new SmarActMCSController(motorPortName, ioPortName, numAxes, movingPollPeriod, idlePollPeriod, disableSpeed);
+    rval = new SmarActMCSController(motorPortName, ioPortName, numAxes, movingPollPeriod, idlePollPeriod, disableSpeed);
 #ifdef ASYN_CANDO_EXCEPTIONS
-	} catch (SmarActMCSException &e) {
-		epicsPrintf("smarActMCSCreateController failed (exception caught):\n%s\n", e.what());
-		rval = 0;
-	}
+  }
+  catch (SmarActMCSException &e) {
+    epicsPrintf("smarActMCSCreateController failed (exception caught):\n%s\n", e.what());
+    rval = 0;
+  }
 #endif
 
-	return rval;
+  return rval;
 }
 
 static void cc_fn(const iocshArgBuf *args)
 {
-	smarActMCSCreateController(
-		args[0].sval,
-		args[1].sval,
-		args[2].ival,
-		args[3].dval,
-		args[4].dval,
-		args[5].ival);
+  smarActMCSCreateController(
+    args[0].sval,
+    args[1].sval,
+    args[2].ival,
+    args[3].dval,
+    args[4].dval,
+    args[5].ival);
 }
 
+static const iocshArg ca_a0 = {"Controller Port name [string]", iocshArgString};
+static const iocshArg ca_a1 = {"Axis number [int]", iocshArgInt};
+static const iocshArg ca_a2 = {"Channel [int]", iocshArgInt};
 
-static const iocshArg ca_a0 = {"Controller Port name [string]",    iocshArgString};
-static const iocshArg ca_a1 = {"Axis number [int]",                iocshArgInt};
-static const iocshArg ca_a2 = {"Channel [int]",                    iocshArgInt};
-
-static const iocshArg * const ca_as[] = {&ca_a0, &ca_a1, &ca_a2};
+static const iocshArg *const ca_as[] = {&ca_a0, &ca_a1, &ca_a2};
 
 /* iocsh wrapping and registration business (stolen from ACRMotorDriver.cpp) */
 /* smarActMCSCreateAxis called to create each axis of the smarActMCS controller*/
@@ -793,68 +791,69 @@ static const iocshFuncDef ca_def = {"smarActMCSCreateAxis", 3, ca_as};
 
 extern "C" void *
 smarActMCSCreateAxis(
-	const char *controllerPortName,
-	int        axisNumber,
-	int        channel)
+  const char *controllerPortName,
+  int axisNumber,
+  int channel)
 {
-void *rval = 0;
+  void *rval = 0;
 
-SmarActMCSController *pC;
-SmarActMCSAxis *pAxis;
-asynMotorAxis *pAsynAxis;
+  SmarActMCSController *pC;
+  //SmarActMCSAxis *pAxis;
+  asynMotorAxis *pAsynAxis;
 
-	// the asyn stuff doesn't seem to be prepared for exceptions. I get segfaults
-	// if constructing a controller (or axis) incurs an exception even if its
-	// caught (IMHO asyn should behave as if the controller/axis never existed...)
+  // the asyn stuff doesn't seem to be prepared for exceptions. I get segfaults
+  // if constructing a controller (or axis) incurs an exception even if its
+  // caught (IMHO asyn should behave as if the controller/axis never existed...)
 #ifdef ASYN_CANDO_EXCEPTIONS
-	try {
+  try {
 #endif
-//		rval = new SmarActMCSAxis(, axisNumber, channel);
-		pC = (SmarActMCSController*) findAsynPortDriver(controllerPortName);
-		if (!pC) {
-			printf("smarActMCSCreateAxis: Error port %s not found\n", controllerPortName);
-			rval = 0;
-			return rval;
-		}
-		// check if axis number already exists
-		pAsynAxis = pC->getAxis(axisNumber);
-		if (pAsynAxis != NULL) { // axis already exists
-			epicsPrintf("SmarActMCSCreateAxis failed:axis %u already exists\n", axisNumber);
+    //		rval = new SmarActMCSAxis(, axisNumber, channel);
+    pC = (SmarActMCSController *)findAsynPortDriver(controllerPortName);
+    if (!pC) {
+      printf("smarActMCSCreateAxis: Error port %s not found\n", controllerPortName);
+      rval = 0;
+      return rval;
+    }
+    // check if axis number already exists
+    pAsynAxis = pC->getAxis(axisNumber);
+    if (pAsynAxis != NULL) { // axis already exists
+      epicsPrintf("SmarActMCSCreateAxis failed:axis %u already exists\n", axisNumber);
 #ifdef ASYN_CANDO_EXCEPTIONS
-			THROW_(SmarActMCSException(MCSCommunicationError, "axis %u already exists", axisNumber));
+      THROW_(SmarActMCSException(MCSCommunicationError, "axis %u already exists", axisNumber));
 #endif
-			rval = 0;
-			return rval;
-		}
-		pC->lock();
-		pAxis = new SmarActMCSAxis(pC, axisNumber, channel);
-		pAxis = NULL;
-		pC->unlock();
+      rval = 0;
+      return rval;
+    }
+    pC->lock();
+    /*pAxis =*/ new SmarActMCSAxis(pC, axisNumber, channel);
+    //pAxis = NULL;
+    pC->unlock();
 
 #ifdef ASYN_CANDO_EXCEPTIONS
-	} catch (SmarActMCSException &e) {
-		epicsPrintf("SmarActMCSAxis failed (exception caught):\n%s\n", e.what());
-		rval = 0;
-	}
+  }
+  catch (SmarActMCSException &e) {
+    epicsPrintf("SmarActMCSAxis failed (exception caught):\n%s\n", e.what());
+    rval = 0;
+  }
 #endif
 
-	return rval;
+  return rval;
 }
 
 static void ca_fn(const iocshArgBuf *args)
 {
-	smarActMCSCreateAxis(
-		args[0].sval,
-		args[1].ival,
-		args[2].ival);
+  smarActMCSCreateAxis(
+    args[0].sval,
+    args[1].ival,
+    args[2].ival);
 }
 
 static void smarActMCSMotorRegister(void)
 {
-  iocshRegister(&cc_def, cc_fn);  // smarActMCSCreateController
-  iocshRegister(&ca_def, ca_fn);  // smarActMCSCreateAxis
+  iocshRegister(&cc_def, cc_fn); // smarActMCSCreateController
+  iocshRegister(&ca_def, ca_fn); // smarActMCSCreateAxis
 }
 
 extern "C" {
-epicsExportRegistrar(smarActMCSMotorRegister);
+  epicsExportRegistrar(smarActMCSMotorRegister);
 }

--- a/smarActApp/src/smarActMCSMotorDriver.h
+++ b/smarActApp/src/smarActMCSMotorDriver.h
@@ -15,84 +15,88 @@
 #include <exception>
 
 enum SmarActMCSExceptionType {
-	MCSUnknownError,
-	MCSConnectionError,
-	MCSCommunicationError,
+  MCSUnknownError,
+  MCSConnectionError,
+  MCSCommunicationError,
 };
 
-class SmarActMCSException : public std::exception {
+class SmarActMCSException : public std::exception
+{
 public:
-	SmarActMCSException(SmarActMCSExceptionType t, const char *fmt, ...);
-	SmarActMCSException(SmarActMCSExceptionType t)
-		: t_(t)
-		{ str_[0] = 0; }
-	SmarActMCSException()
-		: t_(MCSUnknownError)
-		{ str_[0] = 0; }
-	SmarActMCSException(SmarActMCSExceptionType t, const char *fmt, va_list ap);
-	SmarActMCSExceptionType getType()
-		const { return t_; }
-	virtual const char *what()
-		const throw() {return str_ ;}
-protected:
-	char str_[100];	
-	SmarActMCSExceptionType t_;
-};
+  SmarActMCSException(SmarActMCSExceptionType t, const char *fmt, ...);
+  SmarActMCSException(SmarActMCSExceptionType t)
+    : t_(t)
+  { str_[0] = 0; }
+  SmarActMCSException()
+    : t_(MCSUnknownError)
+  { str_[0] = 0; }
+  SmarActMCSException(SmarActMCSExceptionType t, const char *fmt, va_list ap);
+  SmarActMCSExceptionType getType()
+    const { return t_; }
+  virtual const char *what()
+    const throw() { return str_; }
 
+protected:
+  char str_[100];
+  SmarActMCSExceptionType t_;
+};
 
 class SmarActMCSAxis : public asynMotorAxis
 {
 public:
-	SmarActMCSAxis(class SmarActMCSController *cnt_p, int axis, int channel);
-	asynStatus  poll(bool *moving_p);
-	asynStatus  move(double position, int relative, double min_vel, double max_vel, double accel);
-	asynStatus  home(double min_vel, double max_vel, double accel, int forwards);
-	asynStatus  stop(double acceleration);
-	asynStatus  setPosition(double position);
-	asynStatus  moveVelocity(double min_vel, double max_vel, double accel);
+  SmarActMCSAxis(class SmarActMCSController *cnt_p, int axis, int channel);
+  asynStatus poll(bool *moving_p);
+  asynStatus move(double position, int relative, double min_vel, double max_vel, double accel);
+  asynStatus home(double min_vel, double max_vel, double accel, int forwards);
+  asynStatus stop(double acceleration);
+  asynStatus setPosition(double position);
+  asynStatus moveVelocity(double min_vel, double max_vel, double accel);
 
-	virtual asynStatus getVal(const char *parm, int *val_p);
-	virtual asynStatus getAngle(int *val_p, int *rev_p);
-	virtual asynStatus moveCmd(const char *cmd, ...);
-	virtual int        getClosedLoop();
-	int        getEncoder();
+  virtual asynStatus getVal(const char *parm, int *val_p);
+  virtual asynStatus getAngle(int *val_p, int *rev_p);
+  virtual asynStatus moveCmd(const char *cmd, ...);
+  virtual int getClosedLoop();
+  int getEncoder();
 
-	int         getVel() const { return vel_; }
-	
+  int getVel() const { return vel_; }
+
 protected:
-	asynStatus  setSpeed(double velocity);
-private:
-	SmarActMCSController   *c_p_;  // pointer to asynMotorController for this axis
-	asynStatus             comStatus_;
-	int                    vel_;
-	unsigned               holdTime_;
-	int                    channel_;
-	int                    sensorType_;
-	int                    isRot_;
-	int					   stepCount_; // open loop current step count
+  asynStatus setSpeed(double velocity);
 
-friend class SmarActMCSController;
+private:
+  SmarActMCSController *c_p_; // pointer to asynMotorController for this axis
+  asynStatus comStatus_;
+  int vel_;
+  unsigned holdTime_;
+  int channel_;
+  int sensorType_;
+  int isRot_;
+  int stepCount_; // open loop current step count
+
+  friend class SmarActMCSController;
 };
 
 class SmarActMCSController : public asynMotorController
 {
 public:
-	SmarActMCSController(const char *portName, const char *IOPortName, int numAxes, double movingPollPeriod, double idlePollPeriod, int disableSpeed = 0);
-	virtual asynStatus sendCmd(size_t *got_p, char *rep, int len, double timeout, const char *fmt, va_list ap);
-	virtual asynStatus sendCmd(size_t *got_p, char *rep, int len, double timeout, const char *fmt, ...);
-	virtual asynStatus sendCmd(size_t *got_p, char *rep, int len, const char *fmt, ...);
-	virtual asynStatus sendCmd(char *rep, int len, const char *fmt, ...);
+  SmarActMCSController(const char *portName, const char *IOPortName, int numAxes, double movingPollPeriod, double idlePollPeriod, int disableSpeed = 0);
+  virtual asynStatus sendCmd(size_t *got_p, char *rep, int len, double timeout, const char *fmt, va_list ap);
+  virtual asynStatus sendCmd(size_t *got_p, char *rep, int len, double timeout, const char *fmt, ...);
+  virtual asynStatus sendCmd(size_t *got_p, char *rep, int len, const char *fmt, ...);
+  virtual asynStatus sendCmd(char *rep, int len, const char *fmt, ...);
 
-	static int parseReply(const char *reply, int *ax_p, int *val_p);
-	static int parseAngle(const char *reply, int *ax_p, int *val_p, int *rot_p);
+  static int parseReply(const char *reply, int *ax_p, int *val_p);
+  static int parseAngle(const char *reply, int *ax_p, int *val_p, int *rot_p);
+
+  /* These are the methods that we override from asynMotorDriver */
 
 protected:
-	SmarActMCSAxis **pAxes_;
+  SmarActMCSAxis **pAxes_;
 
 private:
-	asynUser *asynUserMot_p_;
-	int disableSpeed_;
-friend class SmarActMCSAxis;
+  asynUser *asynUserMot_p_;
+  int disableSpeed_;
+  friend class SmarActMCSAxis;
 };
 
 #endif // _cplusplus

--- a/smarActApp/src/smarActSCUMotorDriver.h
+++ b/smarActApp/src/smarActSCUMotorDriver.h
@@ -24,38 +24,38 @@ class SmarActSCUException : public std::exception {
 public:
   SmarActSCUException(SmarActSCUExceptionType t, const char *fmt, ...);
   SmarActSCUException(SmarActSCUExceptionType t)
-    : t_(t)
-    { str_[0] = 0; }
+      : t_(t)
+  { str_[0] = 0; }
   SmarActSCUException()
-    : t_(SCUUnknownError)
-    { str_[0] = 0; }
+      : t_(SCUUnknownError)
+  { str_[0] = 0; }
   SmarActSCUException(SmarActSCUExceptionType t, const char *fmt, va_list ap);
   SmarActSCUExceptionType getType()
-    const { return t_; }
+      const { return t_; }
   virtual const char *what()
-    const throw() {return str_ ;}
+      const throw() { return str_; }
+
 protected:
-  char str_[100];  
+  char str_[100];
   SmarActSCUExceptionType t_;
 };
-
 
 class SmarActSCUAxis : public asynMotorAxis
 {
 public:
   SmarActSCUAxis(class SmarActSCUController *cnt_p, int axis, int channel);
-  asynStatus  poll(bool *moving_p);
-  asynStatus  move(double position, int relative, double min_vel, double max_vel, double accel);
-  asynStatus  home(double min_vel, double max_vel, double accel, int forwards);
-  asynStatus  stop(double acceleration);
-  asynStatus  setPosition(double position);
-  asynStatus  moveVelocity(double min_vel, double max_vel, double accel);
+  asynStatus poll(bool *moving_p);
+  asynStatus move(double position, int relative, double min_vel, double max_vel, double accel);
+  asynStatus home(double min_vel, double max_vel, double accel, int forwards);
+  asynStatus stop(double acceleration);
+  asynStatus setPosition(double position);
+  asynStatus moveVelocity(double min_vel, double max_vel, double accel);
 
   virtual asynStatus getCharVal(const char *parm, char *val_p);
   virtual asynStatus getIntegerVal(const char *parm, int *val_p);
   virtual asynStatus getDoubleVal(const char *parm, double *val_p);
   virtual asynStatus getAngle(double *val_p, int *rev_p);
-  virtual int        getClosedLoop();
+  virtual int getClosedLoop();
 
   int getMaxFreq() const { return maxFreq_; }
 
@@ -63,19 +63,19 @@ protected:
   asynStatus setSpeed(double velocity);
 
 private:
-  SmarActSCUController   *pC_;  // pointer to asynMotorController for this axis
-  asynStatus             comStatus_;
-  int                    maxFreq_;
-  unsigned               holdTime_;
-  int                    channel_;
-  int                    positionerType_;
-  int                    isRot_;
-  double                 positionOffset_;
-  asynStatus             sendCmd();
+  SmarActSCUController *pC_; // pointer to asynMotorController for this axis
+  asynStatus comStatus_;
+  int maxFreq_;
+  unsigned holdTime_;
+  int channel_;
+  int positionerType_;
+  int isRot_;
+  double positionOffset_;
+  asynStatus sendCmd();
   char toController_[MAX_CONTROLLER_STRING_SIZE];
   char fromController_[MAX_CONTROLLER_STRING_SIZE];
 
-friend class SmarActSCUController;
+  friend class SmarActSCUController;
 };
 
 class SmarActSCUController : public asynMotorController
@@ -90,7 +90,7 @@ protected:
   SmarActSCUAxis **pAxes_;
 
 private:
-friend class SmarActSCUAxis;
+  friend class SmarActSCUAxis;
 };
 
 #endif // _cplusplus


### PR DESCRIPTION
The pull request consists of 2 commits:
1. reindent anf formating code -> code consistency has been checkt with bcompare
2. many changes on MCS to support rotary encoder and to set the positioner type
    further this commit contains also many improvements of the MCS2 code

1. reindent, delete trailling spaces, remove unused variables

2. MCS: merge lost features from 1.5.1, MCS2: various
    - merge features of MCS driver that were lost since from version 1.5.0
      - Add PTYPE, MCF, AUTO_ZERO, CAL option
      - Fix jog for rot stages
    - support PTYPE, MCF and other MCS/MCS2 specific functionalities
    - MCS2: fix polling when there are missing positioner
    - MCS2: support positioners without encoder
    - simplify debugging with DBG_PRINTF

