### PR TITLE
Don't include as.dbd in the example IOC

### DIFF
--- a/iocs/smarActIOC/smarActApp/src/Makefile
+++ b/iocs/smarActIOC/smarActApp/src/Makefile
@@ -43,7 +43,7 @@ smarAct_DBD += devIocStats.dbd iocAdmin.dbd
 smarAct_LIBS += devIocStats
 endif
 ifdef AUTOSAVE
-smarAct_DBD += asSupport.dbd as.dbd
+smarAct_DBD += asSupport.dbd
 smarAct_LIBS += autosave
 endif
 


### PR DESCRIPTION
Don't include as.dbd in the example IOC; it is only intended for use with the example autosave IOC