### PR TITLE
Split the EXAMPLE_RELEASE.local into two files

### DIFF
--- a/configure/EXAMPLE_RELEASE.local
+++ b/configure/EXAMPLE_RELEASE.local
@@ -1,14 +1,6 @@
-# define all modules if building outside motor
-SUPPORT=
-ASYN=$(SUPPORT)/asyn
-BUSY=$(SUPPORT)/busy
-IPAC=$(SUPPORT)/ipac
-#optional DEVIOCSTATS, AUTOSAVE
-#DEVIOCSTATS=$(SUPPORT)/iocStats
-AUTOSAVE=$(SUPPORT)/autosave
-
+# The path to the motor module is required
 MOTOR=
+# Automatically include all of the modules that were used to build motor
 -include $(MOTOR)/modules/RELEASE.$(EPICS_HOST_ARCH).local
-# path to motorSmarAct is needed to build the IOC inside motorSmarAct, but outside motor
+# The path to motorSmarAct is needed to build the IOC inside motorSmarAct, but outside motor
 MOTOR_SMARACT=
-EPICS_BASE=

--- a/configure/EXAMPLE_RELEASE_FULL.local
+++ b/configure/EXAMPLE_RELEASE_FULL.local
@@ -1,0 +1,13 @@
+# Manually define all modules if building outside motor
+SUPPORT=
+ASYN=$(SUPPORT)/asyn
+BUSY=$(SUPPORT)/busy
+IPAC=$(SUPPORT)/ipac
+#optional DEVIOCSTATS, AUTOSAVE
+#DEVIOCSTATS=$(SUPPORT)/iocStats
+AUTOSAVE=$(SUPPORT)/autosave
+
+MOTOR=
+# path to motorSmarAct is needed to build the IOC inside motorSmarAct, but outside motor
+MOTOR_SMARACT=
+EPICS_BASE=


### PR DESCRIPTION
Split the EXAMPLE_RELEASE.local into two files, to make the two approaches to defining required modules more obvious